### PR TITLE
Fix features

### DIFF
--- a/snips-nlu-lib/Cargo.toml
+++ b/snips-nlu-lib/Cargo.toml
@@ -13,7 +13,7 @@ snips-nlu-resources-packed = { path = "../snips-nlu-resources-packed" }
 crfsuite = { git = "https://github.com/snipsco/crfsuite-rs", rev = "b18d95c" }
 snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.54.2" }
 snips-nlu-ontology-parsers = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.54.2" }
-snips-nlu-utils = { git = "https://github.com/snipsco/snips-nlu-utils", tag = "0.6.0" }
+snips-nlu-utils = { git = "https://github.com/snipsco/snips-nlu-utils", tag = "0.6.1" }
 dinghy-test = "0.3"
 failure = "0.1"
 base64 = "0.9"

--- a/snips-nlu-lib/src/intent_classifier/log_reg_intent_classifier.rs
+++ b/snips-nlu-lib/src/intent_classifier/log_reg_intent_classifier.rs
@@ -101,6 +101,15 @@ impl IntentClassifier for LogRegIntentClassifier {
     }
 }
 
+impl LogRegIntentClassifier {
+    pub fn compute_features(&self, input: &str) -> Result<Array1<f32>> {
+        self.featurizer
+            .as_ref()
+            .map(|featurizer| featurizer.transform(input))
+            .unwrap_or_else(|| Ok(Array::from_iter(vec![])))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/snips-nlu-lib/src/lib.rs
+++ b/snips-nlu-lib/src/lib.rs
@@ -38,9 +38,11 @@ mod utils;
 
 pub const MODEL_VERSION: &str = "0.14.0";
 
-pub use configurations::{FileBasedConfiguration, NluEngineConfiguration,
-                         NluEngineConfigurationConvertible, ZipBasedConfiguration};
+pub use configurations::*;
 pub use errors::*;
+pub use intent_classifier::{IntentClassifier, LogRegIntentClassifier};
+pub use intent_parser::{DeterministicIntentParser, IntentParser, ProbabilisticIntentParser};
 pub use nlu_engine::SnipsNluEngine;
+pub use slot_filler::{CRFSlotFiller, SlotFiller};
 pub use nlu_utils::token::{compute_all_ngrams, tokenize_light};
 pub use utils::file_path; // This is used by benches

--- a/snips-nlu-lib/src/slot_filler/crf_slot_filler.rs
+++ b/snips-nlu-lib/src/slot_filler/crf_slot_filler.rs
@@ -142,6 +142,16 @@ impl SlotFiller for CRFSlotFiller {
     }
 }
 
+impl CRFSlotFiller {
+    pub fn compute_features(&self, text: &str) -> Vec<Vec<(String, String)>> {
+        let tokens = tokenize(text, NluUtilsLanguage::from_language(self.language));
+        if tokens.is_empty() {
+            return vec![];
+        };
+        self.feature_processor.compute_features(&&*tokens)
+    }
+}
+
 // We need to use base64 encoding to ensure ascii encoding because of encoding issues in
 // python-crfsuite
 

--- a/snips-nlu-lib/src/slot_filler/feature_processor.rs
+++ b/snips-nlu-lib/src/slot_filler/feature_processor.rs
@@ -173,7 +173,7 @@ fn prefix_feature_function(
 ) -> Result<FeatureFunction> {
     let n = parse_as_u64(args, "prefix_size")? as usize;
     Ok(FeatureFunction::new(
-        &format!("prefix-{}", n),
+        &format!("prefix_{}", n),
         offsets,
         move |t, i| features::prefix(&t[i].value, n),
     ))
@@ -185,7 +185,7 @@ fn suffix_feature_function(
 ) -> Result<FeatureFunction> {
     let n = parse_as_u64(args, "suffix_size")? as usize;
     Ok(FeatureFunction::new(
-        &format!("suffix-{}", n),
+        &format!("suffix_{}", n),
         offsets,
         move |t, i| features::suffix(&t[i].value, n),
     ))

--- a/snips-nlu-lib/src/slot_filler/features.rs
+++ b/snips-nlu-lib/src/slot_filler/features.rs
@@ -1,9 +1,9 @@
 use itertools::Itertools;
 
 use super::crf_utils::{get_scheme_prefix, TaggingScheme};
-use super::features_utils::{get_shape, get_word_chunk, initial_string_from_tokens};
+use super::features_utils::{get_word_chunk, initial_string_from_tokens};
 use nlu_utils::range::ranges_overlap;
-use nlu_utils::string::normalize;
+use nlu_utils::string::{get_shape, normalize};
 use nlu_utils::token::{compute_all_ngrams, Token};
 use resources::gazetteer::Gazetteer;
 #[cfg(test)]

--- a/snips-nlu-lib/src/slot_filler/features_utils.rs
+++ b/snips-nlu-lib/src/slot_filler/features_utils.rs
@@ -24,30 +24,6 @@ pub fn get_word_chunk(
     }
 }
 
-pub fn get_shape(string: &str) -> String {
-    if string.chars().all(char::is_lowercase) {
-        "xxx".to_string()
-    } else if string.chars().all(char::is_uppercase) {
-        "XXX".to_string()
-    } else if is_title_case(string) {
-        "Xxx".to_string()
-    } else {
-        "xX".to_string()
-    }
-}
-
-fn is_title_case(string: &str) -> bool {
-    let mut first = true;
-    for c in string.chars() {
-        match (first, c.is_uppercase()) {
-            (true, true) => first = false,
-            (false, false) => continue,
-            _ => return false,
-        }
-    }
-    !first
-}
-
 pub fn initial_string_from_tokens(tokens: &[Token]) -> String {
     let mut current_index = 0;
     let mut chunks: Vec<String> = Vec::with_capacity(2 * tokens.len() - 1);
@@ -112,19 +88,6 @@ mod tests {
 
         // Then
         assert_eq!(word_chunk, None);
-    }
-
-    #[test]
-    fn get_shape_works() {
-        // Given
-        let inputs = vec!["héllo", "Héllo", "HÉLLO", "hélLo", "!!", "Éllo", "É"];
-
-        // When
-        let actual_shapes: Vec<String> = inputs.into_iter().map(|i| get_shape(i)).collect();
-
-        // Then
-        let expected_shapes = vec!["xxx", "Xxx", "XXX", "xX", "xX", "Xxx", "XXX"];
-        assert_eq!(actual_shapes, expected_shapes)
     }
 
     #[test]

--- a/snips-nlu-resources/Cargo.toml
+++ b/snips-nlu-resources/Cargo.toml
@@ -8,4 +8,4 @@ csv = "0.15"
 failure = "0.1"
 itertools = { version = "0.7", default-features = false }
 lazy_static = "1.0"
-snips-nlu-utils = { git = "https://github.com/snipsco/snips-nlu-utils", tag = "0.6.0" }
+snips-nlu-utils = { git = "https://github.com/snipsco/snips-nlu-utils", tag = "0.6.1" }


### PR DESCRIPTION
**Description**
This PR fixes various issues with CRF slot filler features:
- use `get_shape` function from `snips-nlu-utils` in order to avoid discrepancy with the Python pipeline
- fix names of prefix and suffix features to match the names of the python pipeline

Additionnally, this PR makes public the following objects:
- all pipeline configurations
- `IntentClassifier` and `LogRegIntentClassifier`
- `IntentParser`, `DeterministicIntentParser` and `ProbabilisticIntentParser`
- `SlotFiller` and `CRFSlotFiller`

These objects (along with their configurations) can be used independently so it makes sense to expose them publicly.