### PR TITLE
Improve caching of builtin entity parsing

### DIFF
--- a/snips-nlu-ffi/Cargo.toml
+++ b/snips-nlu-ffi/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
 [dependencies]
 ffi-utils = { git = "https://github.com/snipsco/snips-utils-rs", rev = "b1f4af3" }
 snips-nlu-lib = { path = "../snips-nlu-lib" }
-snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.55.0" }
+snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.57.0" }
 failure = "0.1"
 lazy_static = "1.0"
 libc = "0.2"

--- a/snips-nlu-lib/Cargo.toml
+++ b/snips-nlu-lib/Cargo.toml
@@ -11,8 +11,8 @@ description = "Rust implementation of Snips NLU"
 [dependencies]
 snips-nlu-resources-packed = { path = "../snips-nlu-resources-packed" }
 crfsuite = { git = "https://github.com/snipsco/crfsuite-rs", rev = "b18d95c" }
-snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.55.0" }
-snips-nlu-ontology-parsers = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.55.0" }
+snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.57.0" }
+snips-nlu-ontology-parsers = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.57.0" }
 snips-nlu-utils = { git = "https://github.com/snipsco/snips-nlu-utils", tag = "0.6.1" }
 dinghy-test = "0.3"
 failure = "0.1"

--- a/snips-nlu-lib/Cargo.toml
+++ b/snips-nlu-lib/Cargo.toml
@@ -18,6 +18,8 @@ dinghy-test = "0.3"
 failure = "0.1"
 base64 = "0.9"
 itertools = { version = "0.7", default-features = false }
+lazy_static = "1.0"
+lru-cache = "0.1.1"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/snips-nlu-lib/src/builtin_entity_parsing.rs
+++ b/snips-nlu-lib/src/builtin_entity_parsing.rs
@@ -1,0 +1,92 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use lru_cache::LruCache;
+
+use snips_nlu_ontology::{BuiltinEntityKind, BuiltinEntity, Language};
+use snips_nlu_ontology_parsers::BuiltinEntityParser;
+
+
+pub struct CachingBuiltinEntityParser {
+    parser: BuiltinEntityParser,
+    cache: Mutex<EntityCache>,
+}
+
+impl CachingBuiltinEntityParser {
+    pub fn new(lang: Language, cache_capacity: usize) -> Self {
+        CachingBuiltinEntityParser {
+            parser: BuiltinEntityParser::new(lang),
+            cache: Mutex::new(EntityCache::new(cache_capacity)),
+        }
+    }
+
+    pub fn extract_entities(
+        &self,
+        sentence: &str,
+        filter_entity_kinds: Option<&[BuiltinEntityKind]>,
+        use_cache: bool,
+    ) -> Vec<BuiltinEntity> {
+        let lowercased_sentence = sentence.to_lowercase();
+        if !use_cache {
+            return self.parser.extract_entities(&lowercased_sentence, filter_entity_kinds);
+        }
+        let cache_key = CacheKey {
+            input: lowercased_sentence,
+            kinds: filter_entity_kinds
+                .map(|entity_kinds| entity_kinds.to_vec())
+                .unwrap_or_else(|| vec![]),
+        };
+
+        self.cache
+            .lock()
+            .unwrap()
+            .cache(&cache_key,
+                   |cache_key| self.parser.extract_entities(&cache_key.input, filter_entity_kinds))
+    }
+}
+
+struct EntityCache(LruCache<CacheKey, Vec<BuiltinEntity>>);
+
+impl EntityCache {
+    fn new(capacity: usize) -> Self {
+        EntityCache(LruCache::new(capacity))
+    }
+
+    fn cache<F: Fn(&CacheKey) -> Vec<BuiltinEntity>>(
+        &mut self,
+        key: &CacheKey,
+        producer: F,
+    ) -> Vec<BuiltinEntity> {
+        let cached_value = self.0.get_mut(key).map(|a| a.clone());
+        if let Some(value) = cached_value {
+            return value;
+        }
+        let value = producer(key);
+        self.0.insert(key.clone(), value.clone());
+        value
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct CacheKey {
+    input: String,
+    kinds: Vec<BuiltinEntityKind>,
+}
+
+pub struct BuiltinEntityParserFactory;
+
+impl BuiltinEntityParserFactory {
+    pub fn get(lang: Language) -> Arc<CachingBuiltinEntityParser> {
+        lazy_static! {
+            static ref CACHED_PARSERS: Mutex<HashMap<Language, Arc<CachingBuiltinEntityParser>>> =
+                Mutex::new(HashMap::new());
+        }
+
+        CACHED_PARSERS
+            .lock()
+            .unwrap()
+            .entry(lang)
+            .or_insert_with(|| Arc::new(CachingBuiltinEntityParser::new(lang, 1000)))
+            .clone()
+    }
+}

--- a/snips-nlu-lib/src/lib.rs
+++ b/snips-nlu-lib/src/lib.rs
@@ -6,6 +6,9 @@ extern crate dinghy_test;
 extern crate failure;
 extern crate itertools;
 #[macro_use]
+extern crate lazy_static;
+extern crate lru_cache;
+#[macro_use]
 extern crate ndarray;
 extern crate regex;
 extern crate serde;
@@ -23,6 +26,7 @@ extern crate zip;
 #[macro_use]
 extern crate maplit;
 
+mod builtin_entity_parsing;
 mod configurations;
 pub mod errors;
 mod intent_classifier;

--- a/snips-nlu-lib/src/nlu_engine.rs
+++ b/snips-nlu-lib/src/nlu_engine.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use itertools::Itertools;
 
+use builtin_entity_parsing::{BuiltinEntityParserFactory, CachingBuiltinEntityParser};
 use configurations::{DatasetMetadata, Entity, NluEngineConfigurationConvertible};
 use errors::*;
 use intent_parser::{DeterministicIntentParser, IntentParser, ProbabilisticIntentParser};
@@ -14,12 +15,11 @@ use nlu_utils::string::{normalize, substring_with_char_range};
 use nlu_utils::token::{compute_all_ngrams, tokenize};
 use slot_utils::resolve_builtin_slots;
 use snips_nlu_ontology::{BuiltinEntityKind, IntentParserResult, Language, Slot, SlotValue};
-use snips_nlu_ontology_parsers::BuiltinEntityParser;
 
 pub struct SnipsNluEngine {
     dataset_metadata: DatasetMetadata,
     parsers: Vec<Box<IntentParser>>,
-    builtin_entity_parser: Arc<BuiltinEntityParser>,
+    builtin_entity_parser: Arc<CachingBuiltinEntityParser>,
 }
 
 impl SnipsNluEngine {
@@ -42,7 +42,7 @@ impl SnipsNluEngine {
             })
             .collect::<Result<Vec<_>>>()?;
         let language = Language::from_str(&nlu_config.dataset_metadata.language_code)?;
-        let builtin_entity_parser = BuiltinEntityParser::get(language);
+        let builtin_entity_parser = BuiltinEntityParserFactory::get(language);
 
         Ok(SnipsNluEngine {
             dataset_metadata: nlu_config.dataset_metadata,
@@ -201,11 +201,11 @@ fn extract_builtin_slot(
     input: String,
     entity_name: String,
     slot_name: String,
-    builtin_entity_parser: &BuiltinEntityParser,
+    builtin_entity_parser: &CachingBuiltinEntityParser,
 ) -> Result<Option<Slot>> {
     let builtin_entity_kind = BuiltinEntityKind::from_identifier(&entity_name)?;
     Ok(builtin_entity_parser
-        .extract_entities(&input, Some(&[builtin_entity_kind]))
+        .extract_entities(&input, Some(&[builtin_entity_kind]), false)
         .first()
         .map(|rustlin_entity| Slot {
             raw_value: substring_with_char_range(input, &rustlin_entity.range),

--- a/snips-nlu-lib/src/slot_filler/feature_processor.rs
+++ b/snips-nlu-lib/src/slot_filler/feature_processor.rs
@@ -2,6 +2,7 @@ use itertools::Itertools;
 use std::collections::HashMap;
 use std::str::FromStr;
 
+use builtin_entity_parsing::BuiltinEntityParserFactory;
 use super::crf_utils::TaggingScheme;
 use super::features;
 use configurations::FeatureFactory;
@@ -11,7 +12,6 @@ use resources::gazetteer::{HashSetGazetteer, StaticMapGazetteer};
 use resources::stemmer::StaticMapStemmer;
 use resources::word_clusterer::StaticMapWordClusterer;
 use snips_nlu_ontology::{BuiltinEntityKind, Language};
-use snips_nlu_ontology_parsers::BuiltinEntityParser;
 
 pub struct ProbabilisticFeatureProcessor {
     functions: Vec<FeatureFunction>,
@@ -235,7 +235,7 @@ fn builtin_entity_match_feature_function(
         .map(|label| {
             let builtin_parser = Language::from_str(&language_code)
                 .ok()
-                .map(BuiltinEntityParser::get);
+                .map(BuiltinEntityParserFactory::get);
             let builtin_entity_kind = BuiltinEntityKind::from_identifier(&label).ok();
             Ok(FeatureFunction::new(
                 &format!("builtin_entity_match_{}", &label),

--- a/snips-nlu-resources-packed/Cargo.toml
+++ b/snips-nlu-resources-packed/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 failure = "0.1"
 lazy_static = "1.0"
 phf = { version = "0.7.21", features = ["unicase"] }
-snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.55.0" }
+snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.57.0" }
 
 [build-dependencies]
 snips-nlu-resources = { path = "../snips-nlu-resources"}


### PR DESCRIPTION
**Description**
The caching of builtin entity parsing is now the responsibility of the client code. 
This PR improves the caching strategy by only caching the parsing of builtin entity when the resolved value is not used, and disabling caching otherwise. Indeed, datetime resolved values must not be cached as they may be relative to the current context (e.g. `in 5 minutes`).