### PR TITLE
Fix quoting issue in csv readers

### DIFF
--- a/snips-nlu-lib/src/resources/stemmer.rs
+++ b/snips-nlu-lib/src/resources/stemmer.rs
@@ -22,6 +22,7 @@ impl HashMapStemmer {
         let mut values = HashMap::<String, String>::new();
         let mut csv_reader = csv::ReaderBuilder::new()
             .delimiter(b',')
+            .quoting(false)
             .flexible(true)
             .has_headers(false)
             .from_reader(reader);
@@ -93,7 +94,7 @@ mod tests {
     fn hashmap_stemmer_works() {
         // Given
         let stems: &[u8] = r#"
-investigate,investigated,investigation
+investigate,investigated,investigation,"investigate
 do,done,don't,doing,did,does"#.as_ref();
 
         // When
@@ -104,6 +105,7 @@ do,done,don't,doing,did,does"#.as_ref();
         let stemmer = stemmer.unwrap();
         assert_eq!(stemmer.stem("don't"), "do".to_string());
         assert_eq!(stemmer.stem("does"), "do".to_string());
+        assert_eq!(stemmer.stem("\"investigate"), "investigate".to_string());
         assert_eq!(stemmer.stem("unknown"), "unknown".to_string());
     }
 }

--- a/snips-nlu-lib/src/resources/word_clusterer.rs
+++ b/snips-nlu-lib/src/resources/word_clusterer.rs
@@ -21,6 +21,7 @@ impl HashMapWordClusterer {
     fn from_reader<R: Read>(reader: R) -> Result<Self> {
         let mut csv_reader = csv::ReaderBuilder::new()
             .delimiter(b'\t')
+            .quoting(false)
             .has_headers(false)
             .from_reader(reader);
         let mut values = HashMap::<String, String>::new();
@@ -103,7 +104,9 @@ mod tests {
         // Given
         let clusters: &[u8] = r#"
 hello	1111111111111
-world	1111110111111"#.as_ref();
+world	1111110111111
+"yolo	1111100111111
+"#.as_ref();
 
         // When
         let clusterer = HashMapWordClusterer::from_reader(clusters);
@@ -113,6 +116,7 @@ world	1111110111111"#.as_ref();
         let clusterer = clusterer.unwrap();
         assert_eq!(clusterer.get_cluster("hello"), Some("1111111111111".to_string()));
         assert_eq!(clusterer.get_cluster("world"), Some("1111110111111".to_string()));
+        assert_eq!(clusterer.get_cluster("\"yolo"), Some("1111100111111".to_string()));
         assert_eq!(clusterer.get_cluster("unknown"), None);
     }
 }


### PR DESCRIPTION
**Description**
This PR fixes an issue with resources (stems and word clusters) containing quote characters. These characters were treated as entry delimiters by the csv reader and it resulted in a parsing error.