### PR TITLE
Add script to update snips-nlu-ontology versions everywhere

### DIFF
--- a/update_ontology_version.sh
+++ b/update_ontology_version.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+NEW_VERSION=${1?"usage $0 <new version>"}
+
+echo "Updating snips-nlu-ontology versions to version ${NEW_VERSION}"
+perl -p -i -e "s/snipsco\/snips-nlu-ontology\".*\$/snipsco\/snips-nlu-ontology\", tag = \"$NEW_VERSION\" }/g" */Cargo.toml
+perl -p -i -e "s/compile \"ai.snips:snips-nlu-ontology:.*\"\$/compile \"ai.snips:snips-nlu-ontology:$NEW_VERSION\"/g" */**/build.gradle


### PR DESCRIPTION
The idea is to run `./update_ontology_version.sh <new_version>` to update safely the ontology versions everywhere it's needed.