### PR TITLE
Migration to Rust 2018

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,12 +15,6 @@ install:
   - if defined MSYS2_BITS set PATH=%PATH%;C:\msys64\mingw%MSYS2_BITS%\bin
   - rustc -V
   - cargo -V
-  - echo [workspace] > Cargo.toml
-  - echo members = [ >> Cargo.toml
-  - echo "snips-nlu-ffi", >> Cargo.toml
-  - echo "snips-nlu-ffi/python/snips-nlu-python-ffi", >> Cargo.toml
-  - echo "snips-nlu-lib", >> Cargo.toml
-  - echo ] >> Cargo.toml
   - ps: (Get-Content snips-nlu-ffi/python/snips-nlu-python-ffi/Cargo.toml) | ForEach-Object { $_ -replace "^snips-nlu-ffi = .*$", "snips-nlu-ffi = { path = `"../..`" }" } | Set-Content snips-nlu-ffi/python/snips-nlu-python-ffi/Cargo.toml
 
 build: false

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 
 target/
 Cargo.lock
-/Cargo.toml
 **/*.rs.bk
 
 ## Idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jobs:
   include:
     - if: env(TRAVIS_BRANCH) = master or branch =~ /^main\/.+$/
       os: osx
-      osx_image: xcode9.3
+      osx_image: xcode10.1
       language: generic
       env:
         - TOXENV=py27
@@ -24,7 +24,7 @@ jobs:
         - MACOS_SWIFT_TESTS=true
     - if: env(TRAVIS_BRANCH) = master or branch =~ /^main\/.+$/
       os: osx
-      osx_image: xcode9.3
+      osx_image: xcode10.1
       language: generic
       env:
         - IOS_SWIFT_TESTS=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: required # This ensures more memory (https://docs.travis-ci.com/user/reference/overview/#Virtualisation-Environment-vs-Operating-System)
-
 jobs:
   allow_failures:
     - rust: nightly

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -3,13 +3,5 @@ set -ev
 
 source .travis/common.sh
 
-echo '
-[workspace]
-members=[
-    "snips-nlu-ffi",
-    "snips-nlu-ffi/python/snips-nlu-python-ffi",
-    "snips-nlu-lib"
-]' > Cargo.toml
-
 echo "Replacing snips-nlu-ffi url for local version"
 perl -p -i -e "s/^snips-nlu-ffi = .*\$/snips-nlu-ffi = { path = \"..\/..\" \}/g" snips-nlu-ffi/python/snips-nlu-python-ffi/Cargo.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Changed
+- Update to Rust 2018
+
 ## [0.61.1] - 2018-12-14
 ### Changed
 - Bump `snips-nlu-ontology` to `0.61.2`
@@ -23,7 +27,7 @@ All notable changes to this project will be documented in this file.
 ## [0.61.0] - 2018-10-16
 ### Changed
 - Entity injection API is now handled by an `NLUInjector` object
- 
+
 ### Added
 - Support for builtin music entities in english
 
@@ -80,7 +84,7 @@ being statically hardcoded, reducing the binary size by 31Mb.
 
 ### Removed
 - `snips-nlu-resources` and `snips-nlu-resources-packed` crates no longer exists.
-- `FileBasedConfiguration`, `ZipBasedConfiguration` and `NluEngineConfigurationConvertible
+- `FileBasedConfiguration`, `ZipBasedConfiguration` and `NluEngineConfigurationConvertible`
 - Rust examples (replaced by interactive CLI).
 
 ## [0.57.2] - 2018-07-12
@@ -145,6 +149,7 @@ being statically hardcoded, reducing the binary size by 31Mb.
 - Improve support for japanese
 - Rename python package to `snips_nlu_rust`
 
+[Unreleased]: https://github.com/snipsco/snips-nlu-rs/compare/0.62.0...HEAD
 [0.61.1]: https://github.com/snipsco/snips-nlu-rs/compare/0.61.0...0.61.1
 [0.62.0]: https://github.com/snipsco/snips-nlu-rs/compare/0.61.0...0.62.0
 [0.61.0]: https://github.com/snipsco/snips-nlu-rs/compare/0.60.1...0.61.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+members = [
+    "snips-nlu-lib",
+    "snips-nlu-ffi",
+    "snips-nlu-ffi/python/snips-nlu-python-ffi",
+]

--- a/snips-nlu-ffi/Cargo.toml
+++ b/snips-nlu-ffi/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "snips-nlu-ffi"
 version = "0.63.0-SNAPSHOT"
+edition = "2018"
 authors = [
     "Adrien Ball <adrien.ball@snips.ai>",
     "Clement Doumouro <clement.doumouro@snips.ai>",

--- a/snips-nlu-ffi/python/snips-nlu-python-ffi/Cargo.toml
+++ b/snips-nlu-ffi/python/snips-nlu-python-ffi/Cargo.toml
@@ -2,6 +2,7 @@
 name = "snips-nlu-python-ffi"
 version = "0.63.0-SNAPSHOT"
 authors = ["Adrien Ball <adrien.ball@snips.ai>"]
+edition = "2018"
 
 [lib]
 name = "snips_nlu_python_ffi"

--- a/snips-nlu-lib/Cargo.toml
+++ b/snips-nlu-lib/Cargo.toml
@@ -12,7 +12,7 @@ description = "Rust implementation of Snips NLU"
 edition = "2018"
 
 [dependencies]
-crfsuite = { git = "https://github.com/snipsco/crfsuite-rs", rev = "30b2ea6" }
+crfsuite = { git = "https://github.com/snipsco/crfsuite-rs", rev = "91fda4b" }
 snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.62.0" }
 snips-nlu-ontology-parsers = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.62.0" }
 snips-nlu-utils = { git = "https://github.com/snipsco/snips-nlu-utils", tag = "0.7.0" }

--- a/snips-nlu-lib/Cargo.toml
+++ b/snips-nlu-lib/Cargo.toml
@@ -9,6 +9,7 @@ authors = [
 ]
 repository = "https://github.com/snipsco/snips-nlu-rs"
 description = "Rust implementation of Snips NLU"
+edition = "2018"
 
 [dependencies]
 crfsuite = { git = "https://github.com/snipsco/crfsuite-rs", rev = "30b2ea6" }

--- a/snips-nlu-lib/benches/nlu_engine.rs
+++ b/snips-nlu-lib/benches/nlu_engine.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate bencher;
-extern crate snips_nlu_lib;
 extern crate dinghy_test;
+extern crate snips_nlu_lib;
 
 use std::env;
 

--- a/snips-nlu-lib/examples/interactive_parsing_cli.rs
+++ b/snips-nlu-lib/examples/interactive_parsing_cli.rs
@@ -2,7 +2,7 @@ extern crate clap;
 extern crate serde_json;
 extern crate snips_nlu_lib;
 
-use clap::{Arg, App};
+use clap::{App, Arg};
 use snips_nlu_lib::SnipsNluEngine;
 use std::io;
 use std::io::Write;
@@ -10,11 +10,13 @@ use std::io::Write;
 fn main() {
     let matches = App::new("snips-nlu-parse")
         .about("Snips NLU interactive CLI for parsing intents")
-        .arg(Arg::with_name("NLU_ENGINE_DIR")
-            .required(true)
-            .takes_value(true)
-            .index(1)
-            .help("path to the trained nlu engine directory"))
+        .arg(
+            Arg::with_name("NLU_ENGINE_DIR")
+                .required(true)
+                .takes_value(true)
+                .index(1)
+                .help("path to the trained nlu engine directory"),
+        )
         .get_matches();
     let engine_dir = matches.value_of("NLU_ENGINE_DIR").unwrap();
 

--- a/snips-nlu-lib/src/entity_parser/builtin_entity_parser.rs
+++ b/snips-nlu-lib/src/entity_parser/builtin_entity_parser.rs
@@ -1,10 +1,11 @@
 use std::path::Path;
 use std::sync::Mutex;
 
-use entity_parser::utils::Cache;
-use errors::*;
 use snips_nlu_ontology::{BuiltinEntityKind, BuiltinEntity};
 use snips_nlu_ontology_parsers::BuiltinEntityParser as _BuiltinEntityParser;
+
+use super::utils::Cache;
+use crate::errors::*;
 
 pub trait BuiltinEntityParser: Send + Sync {
     fn extract_entities(

--- a/snips-nlu-lib/src/entity_parser/builtin_entity_parser.rs
+++ b/snips-nlu-lib/src/entity_parser/builtin_entity_parser.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::sync::Mutex;
 
-use snips_nlu_ontology::{BuiltinEntityKind, BuiltinEntity};
+use snips_nlu_ontology::{BuiltinEntity, BuiltinEntityKind};
 use snips_nlu_ontology_parsers::BuiltinEntityParser as _BuiltinEntityParser;
 
 use super::utils::Cache;
@@ -36,7 +36,9 @@ impl BuiltinEntityParser for CachingBuiltinEntityParser {
     ) -> Result<Vec<BuiltinEntity>> {
         let lowercased_sentence = sentence.to_lowercase();
         if !use_cache {
-            return self.parser.extract_entities(&lowercased_sentence, filter_entity_kinds);
+            return self
+                .parser
+                .extract_entities(&lowercased_sentence, filter_entity_kinds);
         }
         let cache_key = CacheKey {
             input: lowercased_sentence,
@@ -48,8 +50,10 @@ impl BuiltinEntityParser for CachingBuiltinEntityParser {
         self.cache
             .lock()
             .unwrap()
-            .try_cache(&cache_key,
-                       |cache_key| self.parser.extract_entities(&cache_key.input, filter_entity_kinds))
+            .try_cache(&cache_key, |cache_key| {
+                self.parser
+                    .extract_entities(&cache_key.input, filter_entity_kinds)
+            })
     }
 }
 

--- a/snips-nlu-lib/src/entity_parser/custom_entity_parser.rs
+++ b/snips-nlu-lib/src/entity_parser/custom_entity_parser.rs
@@ -8,16 +8,15 @@ use failure::ResultExt;
 use itertools::Itertools;
 use nlu_utils::language::Language as NluUtilsLanguage;
 use nlu_utils::token::*;
-use serde_json;
 use serde::{Deserialize, Deserializer};
 use serde::de::{Unexpected, Error as SerdeError};
 use snips_nlu_ontology::Language;
 use snips_nlu_ontology_parsers::{GazetteerEntityMatch, GazetteerParser};
 
-use entity_parser::utils::Cache;
-use errors::*;
-use language::FromLanguage;
-use utils::EntityName;
+use crate::entity_parser::utils::Cache;
+use crate::errors::*;
+use crate::language::FromLanguage;
+use crate::utils::EntityName;
 
 pub type CustomEntity = GazetteerEntityMatch<String>;
 
@@ -166,7 +165,7 @@ impl CachingCustomEntityParser {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use testutils::file_path;
+    use crate::testutils::file_path;
 
     #[test]
     fn should_compute_char_shifts() {

--- a/snips-nlu-lib/src/entity_parser/custom_entity_parser.rs
+++ b/snips-nlu-lib/src/entity_parser/custom_entity_parser.rs
@@ -42,7 +42,7 @@ impl<'de> Deserialize<'de> for CustomEntityParserUsage {
             1 => Ok(CustomEntityParserUsage::WithoutStems),
             2 => Ok(CustomEntityParserUsage::WithAndWithoutStems),
             other => Err(D::Error::invalid_value(
-                Unexpected::Unsigned(other as u64),
+                Unexpected::Unsigned(u64::from(other)),
                 &"CustomEntityParserUsage expects 0, 1 or 2",
             )),
         }?;
@@ -118,7 +118,7 @@ impl CachingCustomEntityParser {
 /// For instance, if "hello?world" is tokenized in ["hello", "?", "world"],
 /// then the character shifts between "hello?world" and "hello ? world" are
 /// [0, 0, 0, 0, 0, 1, 1, 2, 2, 2, 2, 2, 2]
-fn compute_char_shifts(tokens: &Vec<Token>) -> Vec<i32> {
+fn compute_char_shifts(tokens: &[Token]) -> Vec<i32> {
     if tokens.is_empty() {
         return vec![];
     }

--- a/snips-nlu-lib/src/entity_parser/custom_entity_parser.rs
+++ b/snips-nlu-lib/src/entity_parser/custom_entity_parser.rs
@@ -8,8 +8,8 @@ use failure::ResultExt;
 use itertools::Itertools;
 use nlu_utils::language::Language as NluUtilsLanguage;
 use nlu_utils::token::*;
+use serde::de::{Error as SerdeError, Unexpected};
 use serde::{Deserialize, Deserializer};
-use serde::de::{Unexpected, Error as SerdeError};
 use snips_nlu_ontology::Language;
 use snips_nlu_ontology_parsers::{GazetteerEntityMatch, GazetteerParser};
 
@@ -37,13 +37,14 @@ pub enum CustomEntityParserUsage {
 
 impl<'de> Deserialize<'de> for CustomEntityParserUsage {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
-
         let usage = match u8::deserialize(deserializer)? {
             0 => Ok(CustomEntityParserUsage::WithStems),
             1 => Ok(CustomEntityParserUsage::WithoutStems),
             2 => Ok(CustomEntityParserUsage::WithAndWithoutStems),
             other => Err(D::Error::invalid_value(
-                Unexpected::Unsigned(other as u64), &"CustomEntityParserUsage expects 0, 1 or 2")),
+                Unexpected::Unsigned(other as u64),
+                &"CustomEntityParserUsage expects 0, 1 or 2",
+            )),
         }?;
         Ok(usage)
     }
@@ -78,8 +79,9 @@ impl CustomEntityParser for CachingCustomEntityParser {
         self.cache
             .lock()
             .unwrap()
-            .try_cache(&cache_key,
-                       |cache_key| self._extract_entities(&cache_key.input, filter_entity_kinds))
+            .try_cache(&cache_key, |cache_key| {
+                self._extract_entities(&cache_key.input, filter_entity_kinds)
+            })
     }
 }
 
@@ -92,7 +94,9 @@ impl CachingCustomEntityParser {
         let tokens = tokenize(sentence, self.language);
         let shifts = compute_char_shifts(&tokens);
         let cleaned_input = tokens.into_iter().map(|token| token.value).join(" ");
-        Ok(self.parser.extract_entities(&cleaned_input, filter_entity_kinds)?
+        Ok(self
+            .parser
+            .extract_entities(&cleaned_input, filter_entity_kinds)?
             .into_iter()
             .map(|mut entity_match| {
                 let range_start = entity_match.range.start;
@@ -102,8 +106,7 @@ impl CachingCustomEntityParser {
                 entity_match.range = remapped_range_start..remapped_range_end;
                 entity_match
             })
-            .collect()
-        )
+            .collect())
     }
 }
 
@@ -147,20 +150,25 @@ pub struct CustomEntityParserMetadata {
 impl CachingCustomEntityParser {
     pub fn from_path<P: AsRef<Path>>(path: P, cache_capacity: usize) -> Result<Self> {
         let metadata_path = path.as_ref().join("metadata.json");
-        let metadata_file = File::open(&metadata_path)
-            .with_context(|_|
-                format!("Cannot open metadata file for custom entity parser at path: {:?}",
-                        metadata_path))?;
+        let metadata_file = File::open(&metadata_path).with_context(|_| {
+            format!(
+                "Cannot open metadata file for custom entity parser at path: {:?}",
+                metadata_path
+            )
+        })?;
         let metadata: CustomEntityParserMetadata = serde_json::from_reader(metadata_file)
             .with_context(|_| "Cannot deserialize custom entity parser metadata")?;
         let language = NluUtilsLanguage::from_language(Language::from_str(&metadata.language)?);
         let gazetteer_parser_path = path.as_ref().join(&metadata.parser_directory);
         let parser = GazetteerParser::from_path(gazetteer_parser_path)?;
         let cache = Mutex::new(Cache::new(cache_capacity));
-        Ok(Self { language, parser, cache })
+        Ok(Self {
+            language,
+            parser,
+            cache,
+        })
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -171,25 +179,16 @@ mod tests {
     fn should_compute_char_shifts() {
         // Given
         let tokens = vec![
-            Token::new(
-                "hello".to_string(),
-                0..5,
-                0..5,
-            ),
-            Token::new(
-                "?".to_string(),
-                5..6,
-                5..6,
-            ),
-            Token::new(
-                "world".to_string(),
-                6..11,
-                6..11,
-            )
+            Token::new("hello".to_string(), 0..5, 0..5),
+            Token::new("?".to_string(), 5..6, 5..6),
+            Token::new("world".to_string(), 6..11, 6..11),
         ];
 
         // When / Then
-        assert_eq!(vec![0, 0, 0, 0, 0, 1, 1, 2, 2, 2, 2, 2, 2], compute_char_shifts(&tokens));
+        assert_eq!(
+            vec![0, 0, 0, 0, 0, 1, 1, 2, 2, 2, 2, 2, 2],
+            compute_char_shifts(&tokens)
+        );
     }
 
     #[test]
@@ -207,14 +206,12 @@ mod tests {
         let entities = custom_entity_parser.extract_entities(input, None).unwrap();
 
         // Then
-        let expected_entities = vec![
-            CustomEntity {
-                value: "hot".to_string(),
-                resolved_value: "hot".to_string(),
-                range: 12..15,
-                entity_identifier: "Temperature".to_string(),
-            }
-        ];
+        let expected_entities = vec![CustomEntity {
+            value: "hot".to_string(),
+            resolved_value: "hot".to_string(),
+            range: 12..15,
+            entity_identifier: "Temperature".to_string(),
+        }];
 
         assert_eq!(expected_entities, entities);
     }

--- a/snips-nlu-lib/src/entity_parser/utils.rs
+++ b/snips-nlu-lib/src/entity_parser/utils.rs
@@ -4,18 +4,21 @@ use lru_cache::LruCache;
 
 use crate::errors::*;
 
-pub struct Cache<K, V>(LruCache<K, V>) where K: Eq + Hash + Clone, V: Clone;
+pub struct Cache<K, V>(LruCache<K, V>)
+where
+    K: Eq + Hash + Clone,
+    V: Clone;
 
-impl<K, V> Cache<K, V> where K: Eq + Hash + Clone, V: Clone {
+impl<K, V> Cache<K, V>
+where
+    K: Eq + Hash + Clone,
+    V: Clone,
+{
     pub fn new(capacity: usize) -> Self {
         Cache(LruCache::new(capacity))
     }
 
-    pub fn try_cache<F: Fn(&K) -> Result<V>>(
-        &mut self,
-        key: &K,
-        producer: F
-    ) -> Result<V> {
+    pub fn try_cache<F: Fn(&K) -> Result<V>>(&mut self, key: &K, producer: F) -> Result<V> {
         let cached_value = self.0.get_mut(key).cloned();
         if let Some(value) = cached_value {
             return Ok(value);

--- a/snips-nlu-lib/src/entity_parser/utils.rs
+++ b/snips-nlu-lib/src/entity_parser/utils.rs
@@ -2,7 +2,7 @@ use std::hash::Hash;
 
 use lru_cache::LruCache;
 
-use errors::*;
+use crate::errors::*;
 
 pub struct Cache<K, V>(LruCache<K, V>) where K: Eq + Hash + Clone, V: Clone;
 

--- a/snips-nlu-lib/src/injection/errors.rs
+++ b/snips-nlu-lib/src/injection/errors.rs
@@ -34,7 +34,9 @@ impl Display for NluInjectionError {
 
 impl From<NluInjectionErrorKind> for NluInjectionError {
     fn from(kind: NluInjectionErrorKind) -> NluInjectionError {
-        NluInjectionError { inner: Context::new(kind) }
+        NluInjectionError {
+            inner: Context::new(kind),
+        }
     }
 }
 

--- a/snips-nlu-lib/src/injection/injection.rs
+++ b/snips-nlu-lib/src/injection/injection.rs
@@ -14,13 +14,14 @@ use snips_nlu_ontology_parsers::gazetteer_entity_parser::{EntityValue as Gazette
                                                           Parser as GazetteerEntityParser};
 use snips_nlu_utils::token::tokenize_light;
 
-use entity_parser::custom_entity_parser::CustomEntityParserMetadata;
-use entity_parser::custom_entity_parser::CustomEntityParserUsage;
-use injection::errors::{NluInjectionError, NluInjectionErrorKind};
-use models::nlu_engine::NluEngineModel;
-use resources::loading::load_engine_shared_resources;
-use resources::stemmer::Stemmer;
-use resources::SharedResources;
+use crate::entity_parser::custom_entity_parser::CustomEntityParserMetadata;
+use crate::entity_parser::custom_entity_parser::CustomEntityParserUsage;
+use crate::models::nlu_engine::NluEngineModel;
+use crate::resources::loading::load_engine_shared_resources;
+use crate::resources::stemmer::Stemmer;
+use crate::resources::SharedResources;
+
+use super::errors::{NluInjectionError, NluInjectionErrorKind};
 
 pub type InjectedEntity = String;
 pub type InjectedValue = String;
@@ -222,7 +223,7 @@ fn get_builtin_parser_info(
                          builtin_entity_parser_metadata_path)
         })?;
     let builtin_parser_metadata: BuiltinParserMetadata =
-        ::serde_json::from_reader(builtin_entity_parser_metadata_file)
+        serde_json::from_reader(builtin_entity_parser_metadata_file)
             .with_context(|_| NluInjectionErrorKind::InternalInjectionError {
                 msg: format!("invalid builtin entity parser metadata format in {:?}",
                              builtin_entity_parser_metadata_path)
@@ -238,7 +239,7 @@ fn get_builtin_parser_info(
                                  gazetteer_parser_metadata_path)
                 })?;
         let gazetteer_parser_metadata: GazetteerParserMetadata =
-            ::serde_json::from_reader(gazetteer_parser_metadata_file)
+            serde_json::from_reader(gazetteer_parser_metadata_file)
                 .with_context(|_| NluInjectionErrorKind::InternalInjectionError {
                     msg: format!("invalid gazetteer parser metadata format in {:?}",
                                  gazetteer_parser_metadata_path)
@@ -261,7 +262,7 @@ fn get_custom_parser_info(
         .with_context(|_| NluInjectionErrorKind::InternalInjectionError {
             msg: format!("could not open custom entity parser metadata file in {:?}", custom_entity_parser_metadata_path)
         })?;
-    let custom_parser_metadata: CustomEntityParserMetadata = ::serde_json::from_reader(
+    let custom_parser_metadata: CustomEntityParserMetadata = serde_json::from_reader(
         custom_entity_parser_metadata_file)
         .with_context(|_| NluInjectionErrorKind::InternalInjectionError {
             msg: format!("invalid custom entity parser metadata format in {:?}", custom_entity_parser_metadata_path)
@@ -273,7 +274,7 @@ fn get_custom_parser_info(
         .with_context(|_| NluInjectionErrorKind::InternalInjectionError {
             msg: format!("could not open gazetteer parser metadata file in {:?}", gazetteer_parser_metadata_path)
         })?;
-    let gazetteer_parser_metadata: GazetteerParserMetadata = ::serde_json::from_reader(
+    let gazetteer_parser_metadata: GazetteerParserMetadata = serde_json::from_reader(
         gazetteer_parser_metadata_file)
         .with_context(|_| NluInjectionErrorKind::InternalInjectionError {
             msg: format!("invalid gazetteer parser metadata format in {:?}", gazetteer_parser_metadata_path)
@@ -292,7 +293,7 @@ fn get_nlu_engine_info<P: AsRef<Path>>(engine_dir: P) -> Result<NluEngineInfo, N
         .with_context(|_| NluInjectionErrorKind::InternalInjectionError {
             msg: format!("could not open nlu engine model file in {:?}", engine_dataset_metadata_path)
         })?;
-    let nlu_engine_model: NluEngineModel = ::serde_json::from_reader(config_file)
+    let nlu_engine_model: NluEngineModel = serde_json::from_reader(config_file)
         .with_context(|_| NluInjectionErrorKind::InternalInjectionError {
             msg: format!("invalid nlu engine model file in {:?}", engine_dataset_metadata_path)
         })?;
@@ -380,12 +381,13 @@ mod tests {
 
     use self::fs_extra::dir;
     use self::tempfile::tempdir;
-    use SharedResources;
     use snips_nlu_ontology::*;
-    use SnipsNluEngine;
+
+    use crate::SharedResources;
+    use crate::SnipsNluEngine;
+    use crate::testutils::file_path;
 
     use super::*;
-    use testutils::file_path;
 
     #[derive(Clone)]
     struct MockedStemmer<'a> {

--- a/snips-nlu-lib/src/injection/injection.rs
+++ b/snips-nlu-lib/src/injection/injection.rs
@@ -69,7 +69,7 @@ impl<P: AsRef<Path>> NluInjector<P> {
     pub fn add_value(mut self, entity: InjectedEntity, value: InjectedValue) -> Self {
         self.entity_values
             .entry(entity)
-            .or_insert(vec![])
+            .or_insert_with(|| vec![])
             .push(value);
         self
     }
@@ -189,7 +189,7 @@ fn get_entity_parsers_dirs(
                     })
                     .ok_or_else(|| {
                         let msg = format!("could not find entity '{}' in engine", entity);
-                        NluInjectionErrorKind::EntityNotInjectable { msg }.into()
+                        NluInjectionErrorKind::EntityNotInjectable { msg }
                     })
             } else if BuiltinGazetteerEntityKind::from_identifier(entity).is_ok() {
                 let builtin_parser_info = maybe_builtin_parser_info.as_ref().ok_or_else(|| {
@@ -208,7 +208,7 @@ fn get_entity_parsers_dirs(
                     })
                     .ok_or_else(|| {
                         let msg = format!("could not find entity '{}' in engine", entity);
-                        NluInjectionErrorKind::EntityNotInjectable { msg }.into()
+                        NluInjectionErrorKind::EntityNotInjectable { msg }
                     })
             } else if GrammarEntityKind::from_identifier(entity).is_ok() {
                 let msg = format!(
@@ -348,13 +348,8 @@ fn get_nlu_engine_info<P: AsRef<Path>>(engine_dir: P) -> Result<NluEngineInfo, N
             msg: "invalid nlu engine language".to_string(),
         })?;
 
-    let custom_entities = HashSet::from_iter(
-        nlu_engine_model
-            .dataset_metadata
-            .entities
-            .keys()
-            .map(|k| k.clone()),
-    );
+    let custom_entities =
+        HashSet::from_iter(nlu_engine_model.dataset_metadata.entities.keys().cloned());
 
     let builtin_entity_parser_dir = engine_dir
         .as_ref()

--- a/snips-nlu-lib/src/injection/injection.rs
+++ b/snips-nlu-lib/src/injection/injection.rs
@@ -9,9 +9,10 @@ use failure::ResultExt;
 use itertools::Itertools;
 use nlu_utils::language::Language as NluUtilsLanguage;
 use snips_nlu_ontology::{BuiltinGazetteerEntityKind, GrammarEntityKind};
+use snips_nlu_ontology_parsers::gazetteer_entity_parser::{
+    EntityValue as GazetteerEntityValue, Parser as GazetteerEntityParser,
+};
 use snips_nlu_ontology_parsers::{BuiltinParserMetadata, GazetteerParserMetadata};
-use snips_nlu_ontology_parsers::gazetteer_entity_parser::{EntityValue as GazetteerEntityValue,
-                                                          Parser as GazetteerEntityParser};
 use snips_nlu_utils::token::tokenize_light;
 
 use crate::entity_parser::custom_entity_parser::CustomEntityParserMetadata;
@@ -30,7 +31,6 @@ fn normalize(s: &str) -> String {
     s.to_lowercase()
 }
 
-
 struct NluEngineInfo {
     language: NluUtilsLanguage,
     builtin_entity_parser_dir: PathBuf,
@@ -38,12 +38,10 @@ struct NluEngineInfo {
     custom_entities: HashSet<InjectedEntity>,
 }
 
-
 struct BuiltinGazetteerParserInfo {
     gazetteer_parser_dir: PathBuf,
     gazetteer_parser_metadata: GazetteerParserMetadata,
 }
-
 
 struct CustomGazetteerParserInfo {
     gazetteer_parser_dir: PathBuf,
@@ -51,14 +49,12 @@ struct CustomGazetteerParserInfo {
     parser_usage: CustomEntityParserUsage,
 }
 
-
 pub struct NluInjector<P: AsRef<Path>> {
     nlu_engine_dir: P,
     entity_values: HashMap<InjectedEntity, Vec<InjectedValue>>,
     from_vanilla: bool,
     shared_resources: Option<Arc<SharedResources>>,
 }
-
 
 impl<P: AsRef<Path>> NluInjector<P> {
     pub fn new(nlu_engine_dir: P) -> Self {
@@ -93,10 +89,8 @@ impl<P: AsRef<Path>> NluInjector<P> {
 
         info!("Retrieving parsers paths...");
         let engine_info = get_nlu_engine_info(self.nlu_engine_dir.as_ref())?;
-        let builtin_parser_info = get_builtin_parser_info(
-            &engine_info.builtin_entity_parser_dir)?;
-        let custom_parser_info = get_custom_parser_info(
-            &engine_info.custom_entity_parser_dir)?;
+        let builtin_parser_info = get_builtin_parser_info(&engine_info.builtin_entity_parser_dir)?;
+        let custom_parser_info = get_custom_parser_info(&engine_info.custom_entity_parser_dir)?;
         let parsers_dirs = get_entity_parsers_dirs(
             &engine_info,
             &builtin_parser_info,
@@ -107,17 +101,22 @@ impl<P: AsRef<Path>> NluInjector<P> {
         let shared_resources = if let Some(resources) = self.shared_resources {
             Ok(resources)
         } else {
-            load_engine_shared_resources(self.nlu_engine_dir.as_ref())
-                .with_context(|_| NluInjectionErrorKind::InternalInjectionError {
-                    msg: format!("Could not load shared resources from {:?}", self.nlu_engine_dir.as_ref())
-                })
+            load_engine_shared_resources(self.nlu_engine_dir.as_ref()).with_context(|_| {
+                NluInjectionErrorKind::InternalInjectionError {
+                    msg: format!(
+                        "Could not load shared resources from {:?}",
+                        self.nlu_engine_dir.as_ref()
+                    ),
+                }
+            })
         }?;
 
         let maybe_stemmer = shared_resources.stemmer.as_ref();
 
         // Normalize and stem all values if needed
         info!("Normalizing injected values...");
-        let normalized_entity_values = self.entity_values
+        let normalized_entity_values = self
+            .entity_values
             .into_iter()
             .map(|(entity, values)| {
                 let normalize_entity_values = normalize_entity_value(values);
@@ -126,7 +125,8 @@ impl<P: AsRef<Path>> NluInjector<P> {
                         normalize_entity_values,
                         &engine_info,
                         &custom_parser_info,
-                        &maybe_stemmer)?;
+                        &maybe_stemmer,
+                    )?;
                     Ok((entity, stemmed_entity_values))
                 } else {
                     Ok((entity, normalize_entity_values))
@@ -140,23 +140,26 @@ impl<P: AsRef<Path>> NluInjector<P> {
             let parser_dir = &parsers_dirs[&entity];
             let mut gazetteer_parser = GazetteerEntityParser::from_folder(parser_dir)
                 .with_context(|_| NluInjectionErrorKind::InternalInjectionError {
-                    msg: format!("could not load gazetteer parser in {:?}", parser_dir)
+                    msg: format!("could not load gazetteer parser in {:?}", parser_dir),
                 })?;
 
-            gazetteer_parser.inject_new_values(new_entity_values, true, self.from_vanilla)
+            gazetteer_parser
+                .inject_new_values(new_entity_values, true, self.from_vanilla)
                 .with_context(|_| NluInjectionErrorKind::InternalInjectionError {
-                    msg: format!("could not inject values for entity '{}'", entity)
+                    msg: format!("could not inject values for entity '{}'", entity),
                 })?;
 
-            fs::remove_dir_all(parser_dir.clone())
-                .with_context(|_| NluInjectionErrorKind::InternalInjectionError {
-                    msg: format!("could not remove previous parser at {:?}", parser_dir)
-                })?;
+            fs::remove_dir_all(parser_dir.clone()).with_context(|_| {
+                NluInjectionErrorKind::InternalInjectionError {
+                    msg: format!("could not remove previous parser at {:?}", parser_dir),
+                }
+            })?;
 
-            gazetteer_parser.dump(&parser_dir)
-                .with_context(|_| NluInjectionErrorKind::InternalInjectionError {
-                    msg: format!("failed to dump gazetteer parser in {:?}", parser_dir)
-                })?;
+            gazetteer_parser.dump(&parser_dir).with_context(|_| {
+                NluInjectionErrorKind::InternalInjectionError {
+                    msg: format!("failed to dump gazetteer parser in {:?}", parser_dir),
+                }
+            })?;
         }
 
         info!("Injection performed with success !");
@@ -164,44 +167,54 @@ impl<P: AsRef<Path>> NluInjector<P> {
     }
 }
 
-
 fn get_entity_parsers_dirs(
     engine_info: &NluEngineInfo,
     maybe_builtin_parser_info: &Option<BuiltinGazetteerParserInfo>,
     custom_parser_info: &CustomGazetteerParserInfo,
     entity_values: &HashMap<String, Vec<String>>,
 ) -> Result<HashMap<String, PathBuf>, NluInjectionError> {
-    entity_values.keys()
+    entity_values
+        .keys()
         .map(|entity| {
             let dir = if engine_info.custom_entities.contains(entity) {
                 custom_parser_info
-                    .gazetteer_parser_metadata.parsers_metadata
+                    .gazetteer_parser_metadata
+                    .parsers_metadata
                     .iter()
                     .find(|metadata| metadata.entity_identifier == *entity)
-                    .map(|metadata|
-                        custom_parser_info.gazetteer_parser_dir.join(&metadata.entity_parser))
+                    .map(|metadata| {
+                        custom_parser_info
+                            .gazetteer_parser_dir
+                            .join(&metadata.entity_parser)
+                    })
                     .ok_or_else(|| {
                         let msg = format!("could not find entity '{}' in engine", entity);
                         NluInjectionErrorKind::EntityNotInjectable { msg }.into()
                     })
             } else if BuiltinGazetteerEntityKind::from_identifier(entity).is_ok() {
-                let builtin_parser_info = maybe_builtin_parser_info
-                    .as_ref()
-                    .ok_or_else(|| {
-                        let msg = format!("could not find gazetteer entity '{}' in engine", entity);
-                        NluInjectionErrorKind::EntityNotInjectable { msg }
-                    })?;
-                builtin_parser_info.gazetteer_parser_metadata.parsers_metadata
+                let builtin_parser_info = maybe_builtin_parser_info.as_ref().ok_or_else(|| {
+                    let msg = format!("could not find gazetteer entity '{}' in engine", entity);
+                    NluInjectionErrorKind::EntityNotInjectable { msg }
+                })?;
+                builtin_parser_info
+                    .gazetteer_parser_metadata
+                    .parsers_metadata
                     .iter()
                     .find(|metadata| metadata.entity_identifier == *entity)
-                    .map(|metadata|
-                        builtin_parser_info.gazetteer_parser_dir.join(&metadata.entity_parser))
+                    .map(|metadata| {
+                        builtin_parser_info
+                            .gazetteer_parser_dir
+                            .join(&metadata.entity_parser)
+                    })
                     .ok_or_else(|| {
                         let msg = format!("could not find entity '{}' in engine", entity);
                         NluInjectionErrorKind::EntityNotInjectable { msg }.into()
                     })
             } else if GrammarEntityKind::from_identifier(entity).is_ok() {
-                let msg = format!("Entity injection is not allowed for grammar entities: '{}'", entity);
+                let msg = format!(
+                    "Entity injection is not allowed for grammar entities: '{}'",
+                    entity
+                );
                 Err(NluInjectionErrorKind::EntityNotInjectable { msg })
             } else {
                 let msg = format!("Unknown entity: '{}'", entity);
@@ -212,38 +225,47 @@ fn get_entity_parsers_dirs(
         .collect::<Result<HashMap<String, PathBuf>, NluInjectionError>>()
 }
 
-
 fn get_builtin_parser_info(
-    builtin_parser_dir: &PathBuf
+    builtin_parser_dir: &PathBuf,
 ) -> Result<Option<BuiltinGazetteerParserInfo>, NluInjectionError> {
     let builtin_entity_parser_metadata_path = builtin_parser_dir.join("metadata.json");
     let builtin_entity_parser_metadata_file = fs::File::open(&builtin_entity_parser_metadata_path)
         .with_context(|_| NluInjectionErrorKind::InternalInjectionError {
-            msg: format!("could not open builtin entity parser metadata file in {:?}",
-                         builtin_entity_parser_metadata_path)
+            msg: format!(
+                "could not open builtin entity parser metadata file in {:?}",
+                builtin_entity_parser_metadata_path
+            ),
         })?;
     let builtin_parser_metadata: BuiltinParserMetadata =
-        serde_json::from_reader(builtin_entity_parser_metadata_file)
+        serde_json::from_reader(builtin_entity_parser_metadata_file).with_context(|_| {
+            NluInjectionErrorKind::InternalInjectionError {
+                msg: format!(
+                    "invalid builtin entity parser metadata format in {:?}",
+                    builtin_entity_parser_metadata_path
+                ),
+            }
+        })?;
+    if let Some(gazetteer_parser_dir) = builtin_parser_metadata
+        .gazetteer_parser
+        .map(|directory_name| builtin_parser_dir.join(directory_name))
+    {
+        let gazetteer_parser_metadata_path = gazetteer_parser_dir.join("metadata.json");
+        let gazetteer_parser_metadata_file = fs::File::open(&gazetteer_parser_metadata_path)
             .with_context(|_| NluInjectionErrorKind::InternalInjectionError {
-                msg: format!("invalid builtin entity parser metadata format in {:?}",
-                             builtin_entity_parser_metadata_path)
+                msg: format!(
+                    "could not open gazetteer parser metadata file in {:?}",
+                    gazetteer_parser_metadata_path
+                ),
             })?;
-    if let Some(gazetteer_parser_dir) = builtin_parser_metadata.gazetteer_parser
-        .map(|directory_name| builtin_parser_dir.join(directory_name)) {
-        let gazetteer_parser_metadata_path = gazetteer_parser_dir
-            .join("metadata.json");
-        let gazetteer_parser_metadata_file =
-            fs::File::open(&gazetteer_parser_metadata_path)
-                .with_context(|_| NluInjectionErrorKind::InternalInjectionError {
-                    msg: format!("could not open gazetteer parser metadata file in {:?}",
-                                 gazetteer_parser_metadata_path)
-                })?;
         let gazetteer_parser_metadata: GazetteerParserMetadata =
-            serde_json::from_reader(gazetteer_parser_metadata_file)
-                .with_context(|_| NluInjectionErrorKind::InternalInjectionError {
-                    msg: format!("invalid gazetteer parser metadata format in {:?}",
-                                 gazetteer_parser_metadata_path)
-                })?;
+            serde_json::from_reader(gazetteer_parser_metadata_file).with_context(|_| {
+                NluInjectionErrorKind::InternalInjectionError {
+                    msg: format!(
+                        "invalid gazetteer parser metadata format in {:?}",
+                        gazetteer_parser_metadata_path
+                    ),
+                }
+            })?;
         let parser_info = BuiltinGazetteerParserInfo {
             gazetteer_parser_dir,
             gazetteer_parser_metadata,
@@ -255,29 +277,43 @@ fn get_builtin_parser_info(
 }
 
 fn get_custom_parser_info(
-    custom_parser_dir: &PathBuf
+    custom_parser_dir: &PathBuf,
 ) -> Result<CustomGazetteerParserInfo, NluInjectionError> {
     let custom_entity_parser_metadata_path = custom_parser_dir.join("metadata.json");
     let custom_entity_parser_metadata_file = fs::File::open(&custom_entity_parser_metadata_path)
         .with_context(|_| NluInjectionErrorKind::InternalInjectionError {
-            msg: format!("could not open custom entity parser metadata file in {:?}", custom_entity_parser_metadata_path)
+            msg: format!(
+                "could not open custom entity parser metadata file in {:?}",
+                custom_entity_parser_metadata_path
+            ),
         })?;
-    let custom_parser_metadata: CustomEntityParserMetadata = serde_json::from_reader(
-        custom_entity_parser_metadata_file)
-        .with_context(|_| NluInjectionErrorKind::InternalInjectionError {
-            msg: format!("invalid custom entity parser metadata format in {:?}", custom_entity_parser_metadata_path)
+    let custom_parser_metadata: CustomEntityParserMetadata =
+        serde_json::from_reader(custom_entity_parser_metadata_file).with_context(|_| {
+            NluInjectionErrorKind::InternalInjectionError {
+                msg: format!(
+                    "invalid custom entity parser metadata format in {:?}",
+                    custom_entity_parser_metadata_path
+                ),
+            }
         })?;
 
     let gazetteer_parser_dir = custom_parser_dir.join(custom_parser_metadata.parser_directory);
     let gazetteer_parser_metadata_path = gazetteer_parser_dir.join("metadata.json");
     let gazetteer_parser_metadata_file = fs::File::open(&gazetteer_parser_metadata_path)
         .with_context(|_| NluInjectionErrorKind::InternalInjectionError {
-            msg: format!("could not open gazetteer parser metadata file in {:?}", gazetteer_parser_metadata_path)
+            msg: format!(
+                "could not open gazetteer parser metadata file in {:?}",
+                gazetteer_parser_metadata_path
+            ),
         })?;
-    let gazetteer_parser_metadata: GazetteerParserMetadata = serde_json::from_reader(
-        gazetteer_parser_metadata_file)
-        .with_context(|_| NluInjectionErrorKind::InternalInjectionError {
-            msg: format!("invalid gazetteer parser metadata format in {:?}", gazetteer_parser_metadata_path)
+    let gazetteer_parser_metadata: GazetteerParserMetadata =
+        serde_json::from_reader(gazetteer_parser_metadata_file).with_context(|_| {
+            NluInjectionErrorKind::InternalInjectionError {
+                msg: format!(
+                    "invalid gazetteer parser metadata format in {:?}",
+                    gazetteer_parser_metadata_path
+                ),
+            }
         })?;
     let parser_info = CustomGazetteerParserInfo {
         gazetteer_parser_dir,
@@ -289,25 +325,43 @@ fn get_custom_parser_info(
 
 fn get_nlu_engine_info<P: AsRef<Path>>(engine_dir: P) -> Result<NluEngineInfo, NluInjectionError> {
     let engine_dataset_metadata_path = engine_dir.as_ref().join("nlu_engine.json");
-    let config_file = fs::File::open(engine_dataset_metadata_path.clone())
-        .with_context(|_| NluInjectionErrorKind::InternalInjectionError {
-            msg: format!("could not open nlu engine model file in {:?}", engine_dataset_metadata_path)
-        })?;
-    let nlu_engine_model: NluEngineModel = serde_json::from_reader(config_file)
-        .with_context(|_| NluInjectionErrorKind::InternalInjectionError {
-            msg: format!("invalid nlu engine model file in {:?}", engine_dataset_metadata_path)
+    let config_file = fs::File::open(engine_dataset_metadata_path.clone()).with_context(|_| {
+        NluInjectionErrorKind::InternalInjectionError {
+            msg: format!(
+                "could not open nlu engine model file in {:?}",
+                engine_dataset_metadata_path
+            ),
+        }
+    })?;
+    let nlu_engine_model: NluEngineModel =
+        serde_json::from_reader(config_file).with_context(|_| {
+            NluInjectionErrorKind::InternalInjectionError {
+                msg: format!(
+                    "invalid nlu engine model file in {:?}",
+                    engine_dataset_metadata_path
+                ),
+            }
         })?;
 
     let language = NluUtilsLanguage::from_str(&*nlu_engine_model.dataset_metadata.language_code)
         .map_err(|_| NluInjectionErrorKind::InternalInjectionError {
-            msg: "invalid nlu engine language".to_string()
+            msg: "invalid nlu engine language".to_string(),
         })?;
 
     let custom_entities = HashSet::from_iter(
-        nlu_engine_model.dataset_metadata.entities.keys().map(|k| k.clone()));
+        nlu_engine_model
+            .dataset_metadata
+            .entities
+            .keys()
+            .map(|k| k.clone()),
+    );
 
-    let builtin_entity_parser_dir = engine_dir.as_ref().join(nlu_engine_model.builtin_entity_parser);
-    let custom_entity_parser_dir = engine_dir.as_ref().join(nlu_engine_model.custom_entity_parser);
+    let builtin_entity_parser_dir = engine_dir
+        .as_ref()
+        .join(nlu_engine_model.builtin_entity_parser);
+    let custom_entity_parser_dir = engine_dir
+        .as_ref()
+        .join(nlu_engine_model.custom_entity_parser);
 
     Ok(NluEngineInfo {
         language,
@@ -317,9 +371,7 @@ fn get_nlu_engine_info<P: AsRef<Path>>(engine_dir: P) -> Result<NluEngineInfo, N
     })
 }
 
-fn normalize_entity_value(
-    entity_values: Vec<InjectedValue>
-) -> Vec<GazetteerEntityValue> {
+fn normalize_entity_value(entity_values: Vec<InjectedValue>) -> Vec<GazetteerEntityValue> {
     entity_values
         .into_iter()
         .map(|value| GazetteerEntityValue {
@@ -337,38 +389,34 @@ fn stem_entity_value(
 ) -> Result<Vec<GazetteerEntityValue>, NluInjectionError> {
     let stemmed_entity_values = match custom_entity_parser_info.parser_usage {
         CustomEntityParserUsage::WithoutStems => vec![],
-        _ => {
-            entity_values
-                .iter()
-                .map(|value| {
-                    let stemmer = &maybe_stemmer
-                        .ok_or(NluInjectionErrorKind::InternalInjectionError {
-                            msg: format!("found {:?} parser usage but no stemmer in NLU engine.",
-                                         custom_entity_parser_info.parser_usage)
-                        })?;
-                    let raw_value = tokenize_light(
-                        &*value.raw_value, engine_info.language)
-                        .into_iter()
-                        .map(|token| stemmer.stem(&*token))
-                        .join(" ");
+        _ => entity_values
+            .iter()
+            .map(|value| {
+                let stemmer =
+                    &maybe_stemmer.ok_or(NluInjectionErrorKind::InternalInjectionError {
+                        msg: format!(
+                            "found {:?} parser usage but no stemmer in NLU engine.",
+                            custom_entity_parser_info.parser_usage
+                        ),
+                    })?;
+                let raw_value = tokenize_light(&*value.raw_value, engine_info.language)
+                    .into_iter()
+                    .map(|token| stemmer.stem(&*token))
+                    .join(" ");
 
-                    Ok(GazetteerEntityValue {
-                        raw_value,
-                        resolved_value: value.resolved_value.clone(),
-                    })
+                Ok(GazetteerEntityValue {
+                    raw_value,
+                    resolved_value: value.resolved_value.clone(),
                 })
-                .collect::<Result<_, NluInjectionError>>()?
-        }
+            })
+            .collect::<Result<_, NluInjectionError>>()?,
     };
     let all_values = match custom_entity_parser_info.parser_usage {
         CustomEntityParserUsage::WithStems => stemmed_entity_values,
         _ => {
             let mut values = entity_values;
             values.extend(stemmed_entity_values);
-            values
-                .into_iter()
-                .unique()
-                .collect::<Vec<_>>()
+            values.into_iter().unique().collect::<Vec<_>>()
         }
     };
     Ok(all_values)
@@ -376,16 +424,16 @@ fn stem_entity_value(
 
 #[cfg(test)]
 mod tests {
-    extern crate tempfile;
     extern crate fs_extra;
+    extern crate tempfile;
 
     use self::fs_extra::dir;
     use self::tempfile::tempdir;
     use snips_nlu_ontology::*;
 
+    use crate::testutils::file_path;
     use crate::SharedResources;
     use crate::SnipsNluEngine;
-    use crate::testutils::file_path;
 
     use super::*;
 
@@ -396,7 +444,8 @@ mod tests {
 
     impl<'a> Stemmer for MockedStemmer<'a> {
         fn stem(&self, value: &str) -> String {
-            let stemmed = self.values
+            let stemmed = self
+                .values
                 .get(value)
                 .map(|stemmed_value| *stemmed_value)
                 .unwrap_or(value)
@@ -407,38 +456,42 @@ mod tests {
 
     #[test]
     fn test_should_inject() {
-        let path = file_path("tests")
-            .join("models")
-            .join("nlu_engine_music");
+        let path = file_path("tests").join("models").join("nlu_engine_music");
 
         let tdir = tempdir().unwrap();
         dir::copy(path, tdir.as_ref(), &dir::CopyOptions::new()).unwrap();
         let engine_dir = tdir.as_ref().join("nlu_engine_music");
-        let engine_shared_resources = load_engine_shared_resources(
-            &engine_dir)
-            .unwrap();
+        let engine_shared_resources = load_engine_shared_resources(&engine_dir).unwrap();
 
-        let stems = vec![("funky", "funk")]
-            .into_iter()
-            .collect();
+        let stems = vec![("funky", "funk")].into_iter().collect();
         let stemmer = MockedStemmer { values: stems };
-        let mocked_resources = Arc::new(
-            SharedResources {
-                builtin_entity_parser: engine_shared_resources.as_ref().builtin_entity_parser.clone(),
-                custom_entity_parser: engine_shared_resources.as_ref().custom_entity_parser.clone(),
-                gazetteers: engine_shared_resources.as_ref().gazetteers.clone(),
-                stemmer: Some(Arc::new(stemmer.clone())),
-                word_clusterers: HashMap::new(),
-                stop_words: HashSet::new()
-            });
+        let mocked_resources = Arc::new(SharedResources {
+            builtin_entity_parser: engine_shared_resources
+                .as_ref()
+                .builtin_entity_parser
+                .clone(),
+            custom_entity_parser: engine_shared_resources
+                .as_ref()
+                .custom_entity_parser
+                .clone(),
+            gazetteers: engine_shared_resources.as_ref().gazetteers.clone(),
+            stemmer: Some(Arc::new(stemmer.clone())),
+            word_clusterers: HashMap::new(),
+            stop_words: HashSet::new(),
+        });
 
         // Behaviour before injection
-        let nlu_engine = SnipsNluEngine::from_path_with_resources(
-            &engine_dir, mocked_resources.clone()).unwrap();
-        let parsing = nlu_engine.parse("je souhaiterais écouter l'album thisisthebestalbum", None).unwrap();
+        let nlu_engine =
+            SnipsNluEngine::from_path_with_resources(&engine_dir, mocked_resources.clone())
+                .unwrap();
+        let parsing = nlu_engine
+            .parse("je souhaiterais écouter l'album thisisthebestalbum", None)
+            .unwrap();
         assert_eq!(parsing.intent.unwrap().intent_name, "adri:PlayMusic");
         assert_eq!(parsing.slots.unwrap(), vec![]);
-        let parsing = nlu_engine.parse("je voudrais ecouter ma playlist funk", None).unwrap();
+        let parsing = nlu_engine
+            .parse("je voudrais ecouter ma playlist funk", None)
+            .unwrap();
         assert_eq!(parsing.intent.unwrap().intent_name, "adri:PlayMusic");
         assert_eq!(parsing.slots.unwrap(), vec![]);
 
@@ -448,10 +501,7 @@ mod tests {
                 "snips/musicAlbum".to_string(),
                 "Thisisthebestalbum".to_string(),
             ),
-            (
-                "playlist".to_string(),
-                "funky".to_string(),
-            )
+            ("playlist".to_string(), "funky".to_string()),
         ];
 
         let mut injector = NluInjector::new(&engine_dir)
@@ -464,8 +514,7 @@ mod tests {
 
         injector.inject().unwrap();
 
-        let injected_resources = load_engine_shared_resources(&engine_dir)
-            .unwrap();
+        let injected_resources = load_engine_shared_resources(&engine_dir).unwrap();
 
         let mocked_injected_resources = SharedResources {
             builtin_entity_parser: injected_resources.builtin_entity_parser.clone(),
@@ -473,37 +522,46 @@ mod tests {
             gazetteers: injected_resources.gazetteers.clone(),
             stemmer: Some(Arc::new(stemmer)),
             word_clusterers: injected_resources.word_clusterers.clone(),
-            stop_words: HashSet::new()
+            stop_words: HashSet::new(),
         };
 
         let nlu_engine = SnipsNluEngine::from_path_with_resources(
-            &engine_dir, Arc::new(mocked_injected_resources)).unwrap();
+            &engine_dir,
+            Arc::new(mocked_injected_resources),
+        )
+        .unwrap();
 
         // Behavior after injection
-        let parsing = nlu_engine.parse("je souhaiterais écouter l'album thisisthebestalbum", None).unwrap();
-        assert_eq!(parsing.intent.unwrap().intent_name, "adri:PlayMusic".to_string());
-        let ground_true_slots = Some(vec![
-            Slot {
-                raw_value: "thisisthebestalbum".to_string(),
-                range: Some(32..50),
-                entity: "snips/musicAlbum".to_string(),
-                slot_name: "musicAlbum".to_string(),
-                value: SlotValue::MusicAlbum(StringValue::from("Thisisthebestalbum")),
-            }
-        ]);
+        let parsing = nlu_engine
+            .parse("je souhaiterais écouter l'album thisisthebestalbum", None)
+            .unwrap();
+        assert_eq!(
+            parsing.intent.unwrap().intent_name,
+            "adri:PlayMusic".to_string()
+        );
+        let ground_true_slots = Some(vec![Slot {
+            raw_value: "thisisthebestalbum".to_string(),
+            range: Some(32..50),
+            entity: "snips/musicAlbum".to_string(),
+            slot_name: "musicAlbum".to_string(),
+            value: SlotValue::MusicAlbum(StringValue::from("Thisisthebestalbum")),
+        }]);
         assert_eq!(parsing.slots, ground_true_slots);
 
-        let parsing = nlu_engine.parse("je voudrais ecouter ma playlist funk", None).unwrap();
-        assert_eq!(parsing.intent.unwrap().intent_name, "adri:PlayMusic".to_string());
-        let ground_true_slots = Some(vec![
-            Slot {
-                raw_value: "funk".to_string(),
-                range: Some(32..36),
-                entity: "playlist".to_string(),
-                slot_name: "playlist".to_string(),
-                value: SlotValue::Custom(StringValue::from("funky")),
-            }
-        ]);
+        let parsing = nlu_engine
+            .parse("je voudrais ecouter ma playlist funk", None)
+            .unwrap();
+        assert_eq!(
+            parsing.intent.unwrap().intent_name,
+            "adri:PlayMusic".to_string()
+        );
+        let ground_true_slots = Some(vec![Slot {
+            raw_value: "funk".to_string(),
+            range: Some(32..36),
+            entity: "playlist".to_string(),
+            slot_name: "playlist".to_string(),
+            value: SlotValue::Custom(StringValue::from("funky")),
+        }]);
         assert_eq!(parsing.slots, ground_true_slots);
     }
 }

--- a/snips-nlu-lib/src/injection/mod.rs
+++ b/snips-nlu-lib/src/injection/mod.rs
@@ -1,5 +1,5 @@
 mod errors;
 mod injection;
 
-pub use self::injection::{InjectedEntity, InjectedValue, NluInjector};
 pub use self::errors::{NluInjectionError, NluInjectionErrorKind};
+pub use self::injection::{InjectedEntity, InjectedValue, NluInjector};

--- a/snips-nlu-lib/src/intent_classifier/featurizer.rs
+++ b/snips-nlu-lib/src/intent_classifier/featurizer.rs
@@ -10,11 +10,11 @@ use nlu_utils::token::{compute_all_ngrams, tokenize_light};
 use snips_nlu_ontology::{BuiltinEntityKind, Language};
 
 use crate::errors::*;
-use crate::models::FeaturizerModel;
 use crate::language::FromLanguage;
-use crate::resources::SharedResources;
+use crate::models::FeaturizerModel;
 use crate::resources::stemmer::Stemmer;
 use crate::resources::word_clusterer::WordClusterer;
+use crate::resources::SharedResources;
 
 pub struct Featurizer {
     best_features: Vec<usize>,
@@ -28,31 +28,35 @@ pub struct Featurizer {
 }
 
 impl Featurizer {
-    pub fn new(
-        model: FeaturizerModel,
-        shared_resources: Arc<SharedResources>,
-    ) -> Result<Self> {
+    pub fn new(model: FeaturizerModel, shared_resources: Arc<SharedResources>) -> Result<Self> {
         let best_features = model.best_features;
         let vocabulary = model.tfidf_vectorizer.vocab;
         let language = Language::from_str(model.language_code.as_ref())?;
         let idf_diag = model.tfidf_vectorizer.idf_diag;
-        let opt_word_clusterer = if let Some(clusters_name) = model
-            .config
-            .word_clusters_name {
+        let opt_word_clusterer = if let Some(clusters_name) = model.config.word_clusters_name {
             Some(
-                shared_resources.word_clusterers
+                shared_resources
+                    .word_clusterers
                     .get(&clusters_name)
                     .map(|clusterer| clusterer.clone())
-                    .ok_or_else(||
-                        format_err!("Cannot find word clusters '{}' in shared resources",
-                        clusters_name))?)
+                    .ok_or_else(|| {
+                        format_err!(
+                            "Cannot find word clusters '{}' in shared resources",
+                            clusters_name
+                        )
+                    })?,
+            )
         } else {
             None
         };
         let stemmer = if model.config.use_stemming {
-            Some(shared_resources.stemmer.as_ref()
-                .map(|shared_stemmer| shared_stemmer.clone())
-                .ok_or_else(|| format_err!("Cannot find stemmer in shared resources"))?)
+            Some(
+                shared_resources
+                    .stemmer
+                    .as_ref()
+                    .map(|shared_stemmer| shared_stemmer.clone())
+                    .ok_or_else(|| format_err!("Cannot find stemmer in shared resources"))?,
+            )
         } else {
             None
         };
@@ -103,19 +107,23 @@ impl Featurizer {
     fn preprocess_utterance(&self, utterance: &str) -> Result<Vec<String>> {
         let language = NluUtilsLanguage::from_language(self.language);
         let tokens = tokenize_light(utterance, language);
-        let word_cluster_features = self.word_clusterer
+        let word_cluster_features = self
+            .word_clusterer
             .clone()
             .map(|clusterer| get_word_cluster_features(&tokens, clusterer))
             .unwrap_or_else(|| vec![]);
         let normalized_stemmed_tokens = normalize_stem(&tokens, self.stemmer.clone());
         let normalized_stemmed_string = normalized_stemmed_tokens.join(" ");
-        let custom_entities_features: Vec<String> = self.shared_resources.custom_entity_parser
+        let custom_entities_features: Vec<String> = self
+            .shared_resources
+            .custom_entity_parser
             .extract_entities(&normalized_stemmed_string, None)?
             .into_iter()
             .map(|entity| get_custom_entity_feature_name(&*entity.entity_identifier, language))
             .collect();
 
-        let builtin_entities = self.shared_resources
+        let builtin_entities = self
+            .shared_resources
             .builtin_entity_parser
             .extract_entities(utterance, None, true)?;
         let builtin_entities_features: Vec<String> = builtin_entities
@@ -128,9 +136,10 @@ impl Featurizer {
             builtin_entities_features,
             custom_entities_features,
             word_cluster_features,
-        ].into_iter()
-            .flat_map(|features| features)
-            .collect())
+        ]
+        .into_iter()
+        .flat_map(|features| features)
+        .collect())
     }
 }
 
@@ -142,10 +151,7 @@ fn get_builtin_entity_feature_name(
     format!("builtinentityfeature{}", e)
 }
 
-fn get_custom_entity_feature_name(
-    entity_name: &str,
-    language: NluUtilsLanguage,
-) -> String {
+fn get_custom_entity_feature_name(entity_name: &str, language: NluUtilsLanguage) -> String {
     let e = tokenize_light(&entity_name.to_lowercase(), language).join("");
     format!("entityfeature{}", e)
 }
@@ -169,8 +175,8 @@ fn normalize_stem(tokens: &[String], opt_stemmer: Option<Arc<Stemmer>>) -> Vec<S
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
     use std::collections::HashMap;
+    use std::collections::HashSet;
     use std::iter::FromIterator;
     use std::sync::Arc;
 
@@ -191,41 +197,40 @@ mod tests {
     #[test]
     fn transform_works() {
         // Given
-        let mocked_custom_parser = MockedCustomEntityParser::from_iter(
-            vec![(
-                "hello this bird is a beauti bird".to_string(),
-                vec![
-                    CustomEntity {
-                        value: "hello".to_string(),
-                        resolved_value: "hello".to_string(),
-                        range: 0..5,
-                        entity_identifier: "greeting".to_string(),
-                    },
-                    CustomEntity {
-                        value: "hello".to_string(),
-                        resolved_value: "hello".to_string(),
-                        range: 0..5,
-                        entity_identifier: "word".to_string(),
-                    },
-                    CustomEntity {
-                        value: "bird".to_string(),
-                        resolved_value: "bird".to_string(),
-                        range: 11..15,
-                        entity_identifier: "animal".to_string(),
-                    },
-                    CustomEntity {
-                        value: "bird".to_string(),
-                        resolved_value: "bird".to_string(),
-                        range: 31..35,
-                        entity_identifier: "animal".to_string(),
-                    }
-                ]
-            )]
-        );
-        let mocked_builtin_parser = MockedBuiltinEntityParser { mocked_outputs: HashMap::new() };
-        let mocked_stemmer = HashMapStemmer::from_iter(
-            vec![("beautiful".to_string(), "beauti".to_string())]
-        );
+        let mocked_custom_parser = MockedCustomEntityParser::from_iter(vec![(
+            "hello this bird is a beauti bird".to_string(),
+            vec![
+                CustomEntity {
+                    value: "hello".to_string(),
+                    resolved_value: "hello".to_string(),
+                    range: 0..5,
+                    entity_identifier: "greeting".to_string(),
+                },
+                CustomEntity {
+                    value: "hello".to_string(),
+                    resolved_value: "hello".to_string(),
+                    range: 0..5,
+                    entity_identifier: "word".to_string(),
+                },
+                CustomEntity {
+                    value: "bird".to_string(),
+                    resolved_value: "bird".to_string(),
+                    range: 11..15,
+                    entity_identifier: "animal".to_string(),
+                },
+                CustomEntity {
+                    value: "bird".to_string(),
+                    resolved_value: "bird".to_string(),
+                    range: 31..35,
+                    entity_identifier: "animal".to_string(),
+                },
+            ],
+        )]);
+        let mocked_builtin_parser = MockedBuiltinEntityParser {
+            mocked_outputs: HashMap::new(),
+        };
+        let mocked_stemmer =
+            HashMapStemmer::from_iter(vec![("beautiful".to_string(), "beauti".to_string())]);
 
         let resources = SharedResources {
             custom_entity_parser: Arc::new(mocked_custom_parser),
@@ -233,7 +238,7 @@ mod tests {
             stemmer: Some(Arc::new(mocked_stemmer)),
             word_clusterers: HashMap::new(),
             gazetteers: HashMap::new(),
-            stop_words: HashSet::new()
+            stop_words: HashSet::new(),
         };
         let best_features = vec![0, 1, 2, 3, 6, 7, 8, 9];
         let vocab = hashmap![
@@ -301,21 +306,17 @@ mod tests {
         // Given
         let language = Language::EN;
         let query_tokens = tokenize_light("I, love House, muSic", language);
-        let word_clusterer = HashMapWordClusterer::from_iter(
-            vec![
-                ("love".to_string(), "cluster_love".to_string()),
-                ("house".to_string(), "cluster_house".to_string())
-            ]
-        );
+        let word_clusterer = HashMapWordClusterer::from_iter(vec![
+            ("love".to_string(), "cluster_love".to_string()),
+            ("house".to_string(), "cluster_house".to_string()),
+        ]);
 
         // When
         let augmented_query = get_word_cluster_features(&query_tokens, Arc::new(word_clusterer));
 
         // Then
-        let expected_augmented_query = vec![
-            "cluster_house".to_string(),
-            "cluster_love".to_string()
-        ];
+        let expected_augmented_query =
+            vec!["cluster_house".to_string(), "cluster_love".to_string()];
         assert_eq!(augmented_query, expected_augmented_query)
     }
 }

--- a/snips-nlu-lib/src/intent_classifier/featurizer.rs
+++ b/snips-nlu-lib/src/intent_classifier/featurizer.rs
@@ -4,17 +4,17 @@ use std::sync::Arc;
 
 use itertools::Itertools;
 use ndarray::prelude::*;
-
-use models::FeaturizerModel;
-use errors::*;
-use language::FromLanguage;
 use nlu_utils::language::Language as NluUtilsLanguage;
 use nlu_utils::string::normalize;
 use nlu_utils::token::{compute_all_ngrams, tokenize_light};
-use resources::SharedResources;
-use resources::stemmer::Stemmer;
-use resources::word_clusterer::WordClusterer;
 use snips_nlu_ontology::{BuiltinEntityKind, Language};
+
+use crate::errors::*;
+use crate::models::FeaturizerModel;
+use crate::language::FromLanguage;
+use crate::resources::SharedResources;
+use crate::resources::stemmer::Stemmer;
+use crate::resources::word_clusterer::WordClusterer;
 
 pub struct Featurizer {
     best_features: Vec<usize>,
@@ -169,22 +169,24 @@ fn normalize_stem(tokens: &[String], opt_stemmer: Option<Arc<Stemmer>>) -> Vec<S
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use std::collections::HashMap;
     use std::iter::FromIterator;
     use std::sync::Arc;
-    use super::{get_word_cluster_features, Featurizer};
 
-    use models::{FeaturizerConfiguration, FeaturizerModel, TfIdfVectorizerModel};
     use nlu_utils::language::Language;
     use nlu_utils::token::tokenize_light;
-    use resources::word_clusterer::HashMapWordClusterer;
-    use testutils::assert_epsilon_eq_array1;
-    use testutils::MockedCustomEntityParser;
-    use entity_parser::custom_entity_parser::CustomEntity;
-    use resources::SharedResources;
-    use testutils::MockedBuiltinEntityParser;
-    use resources::stemmer::HashMapStemmer;
-    use std::collections::HashSet;
+
+    use crate::entity_parser::custom_entity_parser::CustomEntity;
+    use crate::models::{FeaturizerConfiguration, FeaturizerModel, TfIdfVectorizerModel};
+    use crate::resources::stemmer::HashMapStemmer;
+    use crate::resources::word_clusterer::HashMapWordClusterer;
+    use crate::resources::SharedResources;
+    use crate::testutils::assert_epsilon_eq_array1;
+    use crate::testutils::MockedBuiltinEntityParser;
+    use crate::testutils::MockedCustomEntityParser;
+
+    use super::{get_word_cluster_features, Featurizer};
 
     #[test]
     fn transform_works() {

--- a/snips-nlu-lib/src/intent_classifier/featurizer.rs
+++ b/snips-nlu-lib/src/intent_classifier/featurizer.rs
@@ -38,7 +38,7 @@ impl Featurizer {
                 shared_resources
                     .word_clusterers
                     .get(&clusters_name)
-                    .map(|clusterer| clusterer.clone())
+                    .cloned()
                     .ok_or_else(|| {
                         format_err!(
                             "Cannot find word clusters '{}' in shared resources",
@@ -54,7 +54,7 @@ impl Featurizer {
                 shared_resources
                     .stemmer
                     .as_ref()
-                    .map(|shared_stemmer| shared_stemmer.clone())
+                    .cloned()
                     .ok_or_else(|| format_err!("Cannot find stemmer in shared resources"))?,
             )
         } else {
@@ -160,7 +160,7 @@ fn get_word_cluster_features(
     query_tokens: &[String],
     word_clusterer: Arc<WordClusterer>,
 ) -> Vec<String> {
-    let tokens_ref = query_tokens.into_iter().map(|t| t.as_ref()).collect_vec();
+    let tokens_ref = query_tokens.iter().map(|t| t.as_ref()).collect_vec();
     compute_all_ngrams(tokens_ref.as_ref(), tokens_ref.len())
         .into_iter()
         .filter_map(|ngram| word_clusterer.get_cluster(&ngram.0.to_lowercase()))

--- a/snips-nlu-lib/src/intent_classifier/log_reg_intent_classifier.rs
+++ b/snips-nlu-lib/src/intent_classifier/log_reg_intent_classifier.rs
@@ -142,12 +142,12 @@ impl LogRegIntentClassifier {
 }
 
 fn get_filtered_out_intents_indexes(
-    intents_list: &Vec<Option<IntentName>>,
+    intents_list: &[Option<IntentName>],
     intents_filter: Option<&HashSet<IntentName>>,
 ) -> Option<Vec<usize>> {
     intents_filter.map(|filter| {
         intents_list
-            .into_iter()
+            .iter()
             .enumerate()
             .filter_map(|(i, opt_intent)| {
                 if let Some(intent) = opt_intent.as_ref() {

--- a/snips-nlu-lib/src/intent_classifier/log_reg_intent_classifier.rs
+++ b/snips-nlu-lib/src/intent_classifier/log_reg_intent_classifier.rs
@@ -3,19 +3,18 @@ use std::fs::File;
 use std::path::Path;
 use std::sync::Arc;
 
+use failure::ResultExt;
 use itertools::Itertools;
 use ndarray::prelude::*;
-use serde_json;
 use snips_nlu_ontology::IntentClassifierResult;
 
-use models::IntentClassifierModel;
-use errors::*;
-use failure::ResultExt;
-use intent_classifier::logreg::MulticlassLogisticRegression;
-use intent_classifier::{Featurizer, IntentClassifier};
-use resources::SharedResources;
+use crate::errors::*;
+use crate::models::IntentClassifierModel;
+use crate::intent_classifier::{Featurizer, IntentClassifier};
+use crate::resources::SharedResources;
+use crate::utils::IntentName;
 
-use utils::IntentName;
+use super::logreg::MulticlassLogisticRegression;
 
 pub struct LogRegIntentClassifier {
     intent_list: Vec<Option<IntentName>>,
@@ -164,9 +163,9 @@ fn get_filtered_out_intents_indexes(
 mod tests {
     use super::*;
 
-    use models::{FeaturizerConfiguration, FeaturizerModel, TfIdfVectorizerModel};
-    use resources::loading::load_engine_shared_resources;
-    use testutils::*;
+    use crate::models::{FeaturizerConfiguration, FeaturizerModel, TfIdfVectorizerModel};
+    use crate::resources::loading::load_engine_shared_resources;
+    use crate::testutils::*;
 
     fn get_sample_log_reg_classifier() -> LogRegIntentClassifier {
         let trained_engine_dir = file_path("tests")

--- a/snips-nlu-lib/src/intent_classifier/log_reg_intent_classifier.rs
+++ b/snips-nlu-lib/src/intent_classifier/log_reg_intent_classifier.rs
@@ -9,8 +9,8 @@ use ndarray::prelude::*;
 use snips_nlu_ontology::IntentClassifierResult;
 
 use crate::errors::*;
-use crate::models::IntentClassifierModel;
 use crate::intent_classifier::{Featurizer, IntentClassifier};
+use crate::models::IntentClassifierModel;
 use crate::resources::SharedResources;
 use crate::utils::IntentName;
 
@@ -25,12 +25,15 @@ pub struct LogRegIntentClassifier {
 impl LogRegIntentClassifier {
     pub fn from_path<P: AsRef<Path>>(
         path: P,
-        shared_resources: Arc<SharedResources>
+        shared_resources: Arc<SharedResources>,
     ) -> Result<Self> {
         let classifier_model_path = path.as_ref().join("intent_classifier.json");
-        let model_file = File::open(&classifier_model_path)
-            .with_context(|_|
-                format!("Cannot open LogRegIntentClassifier file '{:?}'", &classifier_model_path))?;
+        let model_file = File::open(&classifier_model_path).with_context(|_| {
+            format!(
+                "Cannot open LogRegIntentClassifier file '{:?}'",
+                &classifier_model_path
+            )
+        })?;
         let model: IntentClassifierModel = serde_json::from_reader(model_file)
             .with_context(|_| "Cannot deserialize LogRegIntentClassifier json data")?;
         Self::new(model, shared_resources)
@@ -40,7 +43,7 @@ impl LogRegIntentClassifier {
 impl LogRegIntentClassifier {
     pub fn new(
         model: IntentClassifierModel,
-        shared_resources: Arc<SharedResources>
+        shared_resources: Arc<SharedResources>,
     ) -> Result<Self> {
         let featurizer: Option<Featurizer> = if let Some(featurizer_model) = model.featurizer {
             Some(Featurizer::new(featurizer_model, shared_resources)?)
@@ -89,10 +92,12 @@ impl IntentClassifier for LogRegIntentClassifier {
 
         if let (Some(featurizer), Some(logreg)) = (self.featurizer.as_ref(), self.logreg.as_ref()) {
             let features = featurizer.transform(input)?;
-            let filtered_out_indexes = get_filtered_out_intents_indexes(&self.intent_list, intents_filter);
+            let filtered_out_indexes =
+                get_filtered_out_intents_indexes(&self.intent_list, intents_filter);
             let probabilities = logreg.run(&features.view(), filtered_out_indexes)?;
 
-            let mut intents_proba: Vec<(&Option<IntentName>, &f32)> = self.intent_list
+            let mut intents_proba: Vec<(&Option<IntentName>, &f32)> = self
+                .intent_list
                 .iter()
                 .zip(probabilities.into_iter())
                 .collect_vec();
@@ -140,11 +145,11 @@ fn get_filtered_out_intents_indexes(
     intents_list: &Vec<Option<IntentName>>,
     intents_filter: Option<&HashSet<IntentName>>,
 ) -> Option<Vec<usize>> {
-    intents_filter.map(|filter|
+    intents_filter.map(|filter| {
         intents_list
             .into_iter()
             .enumerate()
-            .filter_map(|(i, opt_intent)|
+            .filter_map(|(i, opt_intent)| {
                 if let Some(intent) = opt_intent.as_ref() {
                     if !filter.contains(intent) {
                         Some(i)
@@ -154,9 +159,9 @@ fn get_filtered_out_intents_indexes(
                 } else {
                     None
                 }
-            )
+            })
             .collect()
-    )
+    })
 }
 
 #[cfg(test)]
@@ -168,9 +173,7 @@ mod tests {
     use crate::testutils::*;
 
     fn get_sample_log_reg_classifier() -> LogRegIntentClassifier {
-        let trained_engine_dir = file_path("tests")
-            .join("models")
-            .join("nlu_engine");
+        let trained_engine_dir = file_path("tests").join("models").join("nlu_engine");
 
         let resources = load_engine_shared_resources(trained_engine_dir).unwrap();
         let language_code = "en".to_string();
@@ -421,14 +424,14 @@ mod tests {
         let config = FeaturizerConfiguration {
             sublinear_tf: false,
             word_clusters_name: None,
-            use_stemming: true
+            use_stemming: true,
         };
 
         let config = FeaturizerModel {
             tfidf_vectorizer,
             best_features,
             config,
-            language_code
+            language_code,
         };
 
         let featurizer = Featurizer::new(config, resources).unwrap();
@@ -541,9 +544,7 @@ mod tests {
     #[test]
     fn from_path_works() {
         // Given
-        let trained_engine_dir = file_path("tests")
-            .join("models")
-            .join("nlu_engine");
+        let trained_engine_dir = file_path("tests").join("models").join("nlu_engine");
 
         let classifier_path = trained_engine_dir
             .join("probabilistic_intent_parser")
@@ -552,7 +553,8 @@ mod tests {
         let resources = load_engine_shared_resources(trained_engine_dir).unwrap();
 
         // When
-        let intent_classifier = LogRegIntentClassifier::from_path(classifier_path, resources).unwrap();
+        let intent_classifier =
+            LogRegIntentClassifier::from_path(classifier_path, resources).unwrap();
         let intent_result = intent_classifier
             .get_intent("Make me one cup of tea please", None)
             .unwrap()
@@ -624,12 +626,13 @@ mod tests {
             Some("intent1".to_string()),
             Some("intent2".to_string()),
             Some("intent3".to_string()),
-            None
+            None,
         ];
         let intents_filter = hashset!["intent1".to_string(), "intent3".to_string()];
 
         // When
-        let filtered_indexes = get_filtered_out_intents_indexes(&intents_list, Some(&intents_filter));
+        let filtered_indexes =
+            get_filtered_out_intents_indexes(&intents_list, Some(&intents_filter));
 
         // Then
         let expected_indexes = Some(vec![1]);

--- a/snips-nlu-lib/src/intent_classifier/logreg.rs
+++ b/snips-nlu-lib/src/intent_classifier/logreg.rs
@@ -1,4 +1,4 @@
-use errors::*;
+use crate::errors::*;
 use ndarray::prelude::*;
 
 /// The multiclass probability estimates are derived from binary (one-vs.-rest)
@@ -71,7 +71,7 @@ fn logit(x: f32) -> f32 {
 #[cfg(test)]
 mod tests {
     use super::MulticlassLogisticRegression;
-    use testutils::assert_epsilon_eq_array1;
+    use crate::testutils::assert_epsilon_eq_array1;
 
     #[test]
     fn multiclass_logistic_regression_works() {

--- a/snips-nlu-lib/src/intent_classifier/logreg.rs
+++ b/snips-nlu-lib/src/intent_classifier/logreg.rs
@@ -40,7 +40,7 @@ impl MulticlassLogisticRegression {
     pub fn run(
         &self,
         features: &ArrayView1<f32>,
-        filtered_out_indexes: Option<Vec<usize>>
+        filtered_out_indexes: Option<Vec<usize>>,
     ) -> Result<Array1<f32>> {
         let reshaped_features = features.into_shape((1, self.nb_features()))?;
         let reshaped_features = stack![Axis(1), array![[1.]], reshaped_features];
@@ -129,7 +129,9 @@ mod tests {
         let regression = MulticlassLogisticRegression::new(intercept, weights).unwrap();
 
         // When
-        let predictions = regression.run(&features.view(), filtered_out_indexes).unwrap();
+        let predictions = regression
+            .run(&features.view(), filtered_out_indexes)
+            .unwrap();
 
         // Then
         let expected_predictions = array![0.67745198, 0.32254802, 0.0];

--- a/snips-nlu-lib/src/intent_classifier/mod.rs
+++ b/snips-nlu-lib/src/intent_classifier/mod.rs
@@ -26,17 +26,21 @@ pub trait IntentClassifier: Send + Sync {
 
 pub fn build_intent_classifier<P: AsRef<Path>>(
     path: P,
-    shared_resources: Arc<SharedResources>
+    shared_resources: Arc<SharedResources>,
 ) -> Result<Box<IntentClassifier>> {
     let metadata_path = path.as_ref().join("metadata.json");
-    let metadata_file = File::open(&metadata_path)
-        .with_context(|_| format!("Cannot open intent classifier metadata file '{:?}'",
-                                  &metadata_path))?;
+    let metadata_file = File::open(&metadata_path).with_context(|_| {
+        format!(
+            "Cannot open intent classifier metadata file '{:?}'",
+            &metadata_path
+        )
+    })?;
     let metadata: ProcessingUnitMetadata = serde_json::from_reader(metadata_file)
         .with_context(|_| "Cannot deserialize intent classifier json data")?;
     match metadata {
-        ProcessingUnitMetadata::LogRegIntentClassifier =>
-            Ok(Box::new(LogRegIntentClassifier::from_path(path, shared_resources)?) as _),
-        _ => Err(format_err!("{:?} is not an intent classifier", metadata))
+        ProcessingUnitMetadata::LogRegIntentClassifier => {
+            Ok(Box::new(LogRegIntentClassifier::from_path(path, shared_resources)?) as _)
+        }
+        _ => Err(format_err!("{:?} is not an intent classifier", metadata)),
     }
 }

--- a/snips-nlu-lib/src/intent_classifier/mod.rs
+++ b/snips-nlu-lib/src/intent_classifier/mod.rs
@@ -7,15 +7,14 @@ use std::fs::File;
 use std::path::Path;
 use std::sync::Arc;
 
-use errors::*;
+use crate::errors::*;
 use failure::ResultExt;
-use serde_json;
 use snips_nlu_ontology::IntentClassifierResult;
 
 pub use self::featurizer::Featurizer;
 pub use self::log_reg_intent_classifier::LogRegIntentClassifier;
-use models::ProcessingUnitMetadata;
-use resources::SharedResources;
+use crate::models::ProcessingUnitMetadata;
+use crate::resources::SharedResources;
 
 pub trait IntentClassifier: Send + Sync {
     fn get_intent(

--- a/snips-nlu-lib/src/intent_parser/deterministic_intent_parser.rs
+++ b/snips-nlu-lib/src/intent_parser/deterministic_intent_parser.rs
@@ -12,18 +12,17 @@ use nlu_utils::range::ranges_overlap;
 use nlu_utils::string::{convert_to_char_range, substring_with_char_range, suffix_from_char_index};
 use nlu_utils::token::{tokenize, tokenize_light};
 use regex::{Regex, RegexBuilder};
-use serde_json;
 use snips_nlu_ontology::{BuiltinEntity, BuiltinEntityKind, Language};
 
-use errors::*;
-use intent_parser::{IntentParser, internal_parsing_result, InternalParsingResult};
-use language::FromLanguage;
-use models::DeterministicParserModel;
-use resources::SharedResources;
-use slot_utils::*;
-use utils::{deduplicate_overlapping_items, EntityName, IntentName, SlotName};
-use entity_parser::custom_entity_parser::CustomEntity;
+use crate::errors::*;
+use crate::entity_parser::custom_entity_parser::CustomEntity;
+use crate::language::FromLanguage;
+use crate::models::DeterministicParserModel;
+use crate::resources::SharedResources;
+use crate::slot_utils::*;
+use crate::utils::{deduplicate_overlapping_items, EntityName, IntentName, SlotName};
 
+use super::{IntentParser, internal_parsing_result, InternalParsingResult};
 
 pub struct DeterministicIntentParser {
     language: Language,
@@ -348,13 +347,14 @@ mod tests {
     use std::iter::FromIterator;
     use std::sync::Arc;
 
-    use super::*;
-
-    use models::{DeterministicParserModel, DeterministicParserConfig};
-    use resources::loading::load_engine_shared_resources;
-    use slot_utils::InternalSlot;
     use snips_nlu_ontology::*;
-    use testutils::*;
+
+    use crate::models::{DeterministicParserConfig, DeterministicParserModel};
+    use crate::resources::loading::load_engine_shared_resources;
+    use crate::slot_utils::InternalSlot;
+    use crate::testutils::*;
+
+    use super::*;
 
     fn test_configuration() -> DeterministicParserModel {
         DeterministicParserModel {

--- a/snips-nlu-lib/src/intent_parser/mod.rs
+++ b/snips-nlu-lib/src/intent_parser/mod.rs
@@ -5,14 +5,14 @@ use std::collections::HashSet;
 use std::path::Path;
 use std::sync::Arc;
 
-use errors::*;
 use snips_nlu_ontology::IntentClassifierResult;
 
-use models::ProcessingUnitMetadata;
+use crate::errors::*;
+use crate::models::ProcessingUnitMetadata;
 pub use self::deterministic_intent_parser::DeterministicIntentParser;
 pub use self::probabilistic_intent_parser::ProbabilisticIntentParser;
-use resources::SharedResources;
-pub use slot_utils::InternalSlot;
+use crate::resources::SharedResources;
+pub use crate::slot_utils::InternalSlot;
 
 pub struct InternalParsingResult {
     pub intent: IntentClassifierResult,

--- a/snips-nlu-lib/src/intent_parser/mod.rs
+++ b/snips-nlu-lib/src/intent_parser/mod.rs
@@ -7,10 +7,10 @@ use std::sync::Arc;
 
 use snips_nlu_ontology::IntentClassifierResult;
 
-use crate::errors::*;
-use crate::models::ProcessingUnitMetadata;
 pub use self::deterministic_intent_parser::DeterministicIntentParser;
 pub use self::probabilistic_intent_parser::ProbabilisticIntentParser;
+use crate::errors::*;
+use crate::models::ProcessingUnitMetadata;
 use crate::resources::SharedResources;
 pub use crate::slot_utils::InternalSlot;
 
@@ -44,13 +44,15 @@ pub trait IntentParser: Send + Sync {
 pub fn build_intent_parser<P: AsRef<Path>>(
     metadata: ProcessingUnitMetadata,
     path: P,
-    shared_resources: Arc<SharedResources>
+    shared_resources: Arc<SharedResources>,
 ) -> Result<Box<IntentParser>> {
     match metadata {
-        ProcessingUnitMetadata::DeterministicIntentParser =>
-            Ok(Box::new(DeterministicIntentParser::from_path(path, shared_resources)?) as _),
-        ProcessingUnitMetadata::ProbabilisticIntentParser =>
-            Ok(Box::new(ProbabilisticIntentParser::from_path(path, shared_resources)?) as _),
-        _ => Err(format_err!("{:?} is not an intent parser", metadata))
+        ProcessingUnitMetadata::DeterministicIntentParser => Ok(Box::new(
+            DeterministicIntentParser::from_path(path, shared_resources)?,
+        ) as _),
+        ProcessingUnitMetadata::ProbabilisticIntentParser => Ok(Box::new(
+            ProbabilisticIntentParser::from_path(path, shared_resources)?,
+        ) as _),
+        _ => Err(format_err!("{:?} is not an intent parser", metadata)),
     }
 }

--- a/snips-nlu-lib/src/intent_parser/probabilistic_intent_parser.rs
+++ b/snips-nlu-lib/src/intent_parser/probabilistic_intent_parser.rs
@@ -4,15 +4,16 @@ use std::iter::FromIterator;
 use std::path::Path;
 use std::sync::Arc;
 
-use errors::*;
 use failure::ResultExt;
-use intent_classifier::{build_intent_classifier, IntentClassifier};
-use intent_parser::{IntentParser, InternalParsingResult};
-use models::ProbabilisticParserModel;
-use resources::SharedResources;
-use serde_json;
-use slot_filler::{build_slot_filler, SlotFiller};
-use utils::IntentName;
+
+use crate::errors::*;
+use crate::intent_classifier::{build_intent_classifier, IntentClassifier};
+use crate::models::ProbabilisticParserModel;
+use crate::resources::SharedResources;
+use crate::slot_filler::{build_slot_filler, SlotFiller};
+use crate::utils::IntentName;
+
+use super::{IntentParser, InternalParsingResult};
 
 pub struct ProbabilisticIntentParser {
     intent_classifier: Box<IntentClassifier>,
@@ -77,10 +78,10 @@ impl IntentParser for ProbabilisticIntentParser {
 
 #[cfg(test)]
 mod tests {
+    use crate::resources::loading::load_engine_shared_resources;
+    use crate::slot_utils::InternalSlot;
+    use crate::testutils::*;
     use super::*;
-    use resources::loading::load_engine_shared_resources;
-    use slot_utils::InternalSlot;
-    use testutils::*;
 
     #[test]
     fn from_path_works() {

--- a/snips-nlu-lib/src/intent_parser/probabilistic_intent_parser.rs
+++ b/snips-nlu-lib/src/intent_parser/probabilistic_intent_parser.rs
@@ -26,16 +26,20 @@ impl ProbabilisticIntentParser {
         shared_resources: Arc<SharedResources>,
     ) -> Result<Self> {
         let parser_model_path = path.as_ref().join("intent_parser.json");
-        let model_file = File::open(&parser_model_path)
-            .with_context(|_|
-                format!("Cannot open ProbabilisticIntentParser file '{:?}'",
-                        &parser_model_path))?;
+        let model_file = File::open(&parser_model_path).with_context(|_| {
+            format!(
+                "Cannot open ProbabilisticIntentParser file '{:?}'",
+                &parser_model_path
+            )
+        })?;
         let model: ProbabilisticParserModel = serde_json::from_reader(model_file)
             .with_context(|_| "Cannot deserialize ProbabilisticIntentParser json data")?;
         let intent_classifier_path = path.as_ref().join("intent_classifier");
-        let intent_classifier = build_intent_classifier(
-            intent_classifier_path, shared_resources.clone())?;
-        let slot_fillers_vec: Result<Vec<_>> = model.slot_fillers.iter()
+        let intent_classifier =
+            build_intent_classifier(intent_classifier_path, shared_resources.clone())?;
+        let slot_fillers_vec: Result<Vec<_>> = model
+            .slot_fillers
+            .iter()
             .map(|metadata| {
                 let slot_filler_path = path.as_ref().join(&metadata.slot_filler_name);
                 Ok((
@@ -45,7 +49,10 @@ impl ProbabilisticIntentParser {
             })
             .collect();
         let slot_fillers = HashMap::from_iter(slot_fillers_vec?);
-        Ok(Self { intent_classifier, slot_fillers })
+        Ok(Self {
+            intent_classifier,
+            slot_fillers,
+        })
     }
 }
 
@@ -57,7 +64,8 @@ impl IntentParser for ProbabilisticIntentParser {
     ) -> Result<Option<InternalParsingResult>> {
         let opt_intent_result = self.intent_classifier.get_intent(input, intents)?;
         if let Some(intent_result) = opt_intent_result {
-            let slots = self.slot_fillers
+            let slots = self
+                .slot_fillers
                 .get(&*intent_result.intent_name)
                 .ok_or_else(|| {
                     format_err!(
@@ -78,38 +86,38 @@ impl IntentParser for ProbabilisticIntentParser {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::resources::loading::load_engine_shared_resources;
     use crate::slot_utils::InternalSlot;
     use crate::testutils::*;
-    use super::*;
 
     #[test]
     fn from_path_works() {
         // Given
-        let trained_engine_path = file_path("tests")
-            .join("models")
-            .join("nlu_engine");
+        let trained_engine_path = file_path("tests").join("models").join("nlu_engine");
 
-        let parser_path = trained_engine_path
-            .join("probabilistic_intent_parser");
+        let parser_path = trained_engine_path.join("probabilistic_intent_parser");
 
         let resources = load_engine_shared_resources(trained_engine_path).unwrap();
 
         // When
         let intent_parser = ProbabilisticIntentParser::from_path(parser_path, resources).unwrap();
-        let parsing_result = intent_parser.parse("make me two cups of coffee", None).unwrap();
+        let parsing_result = intent_parser
+            .parse("make me two cups of coffee", None)
+            .unwrap();
 
         // Then
         let expected_intent = Some("MakeCoffee");
-        let expected_slots = Some(vec![
-            InternalSlot {
-                value: "two".to_string(),
-                char_range: 8..11,
-                entity: "snips/number".to_string(),
-                slot_name: "number_of_cups".to_string(),
-            }
-        ]);
-        assert_eq!(expected_intent, parsing_result.as_ref().map(|res| &*res.intent.intent_name));
+        let expected_slots = Some(vec![InternalSlot {
+            value: "two".to_string(),
+            char_range: 8..11,
+            entity: "snips/number".to_string(),
+            slot_name: "number_of_cups".to_string(),
+        }]);
+        assert_eq!(
+            expected_intent,
+            parsing_result.as_ref().map(|res| &*res.intent.intent_name)
+        );
         assert_eq!(expected_slots, parsing_result.map(|res| res.slots));
     }
 }

--- a/snips-nlu-lib/src/lib.rs
+++ b/snips-nlu-lib/src/lib.rs
@@ -28,12 +28,12 @@ extern crate maplit;
 extern crate snips_nlu_utils;
 
 mod entity_parser;
-pub mod models;
 pub mod errors;
 pub mod injection;
 mod intent_classifier;
 mod intent_parser;
 mod language;
+pub mod models;
 mod nlu_engine;
 mod resources;
 mod slot_filler;
@@ -44,14 +44,16 @@ mod utils;
 
 pub const MODEL_VERSION: &str = "0.18.0";
 
-pub use crate::models::*;
 pub use crate::errors::*;
 pub use crate::intent_classifier::{IntentClassifier, LogRegIntentClassifier};
-pub use crate::intent_parser::{DeterministicIntentParser, IntentParser, ProbabilisticIntentParser};
+pub use crate::intent_parser::{
+    DeterministicIntentParser, IntentParser, ProbabilisticIntentParser,
+};
+pub use crate::models::*;
 pub use crate::nlu_engine::SnipsNluEngine;
-pub use crate::slot_filler::{CRFSlotFiller, SlotFiller};
 pub use crate::resources::loading::load_shared_resources;
 pub use crate::resources::SharedResources;
+pub use crate::slot_filler::{CRFSlotFiller, SlotFiller};
 
-pub use snips_nlu_ontology::Language;
 pub use nlu_utils::token::{compute_all_ngrams, tokenize_light};
+pub use snips_nlu_ontology::Language;

--- a/snips-nlu-lib/src/lib.rs
+++ b/snips-nlu-lib/src/lib.rs
@@ -44,13 +44,14 @@ mod utils;
 
 pub const MODEL_VERSION: &str = "0.18.0";
 
-pub use models::*;
-pub use errors::*;
+pub use crate::models::*;
+pub use crate::errors::*;
+pub use crate::intent_classifier::{IntentClassifier, LogRegIntentClassifier};
+pub use crate::intent_parser::{DeterministicIntentParser, IntentParser, ProbabilisticIntentParser};
+pub use crate::nlu_engine::SnipsNluEngine;
+pub use crate::slot_filler::{CRFSlotFiller, SlotFiller};
+pub use crate::resources::loading::load_shared_resources;
+pub use crate::resources::SharedResources;
+
 pub use snips_nlu_ontology::Language;
-pub use intent_classifier::{IntentClassifier, LogRegIntentClassifier};
-pub use intent_parser::{DeterministicIntentParser, IntentParser, ProbabilisticIntentParser};
-pub use nlu_engine::SnipsNluEngine;
-pub use slot_filler::{CRFSlotFiller, SlotFiller};
 pub use nlu_utils::token::{compute_all_ngrams, tokenize_light};
-pub use resources::loading::load_shared_resources;
-pub use resources::SharedResources;

--- a/snips-nlu-lib/src/models/intent_classifier.rs
+++ b/snips-nlu-lib/src/models/intent_classifier.rs
@@ -22,7 +22,7 @@ pub struct FeaturizerModel {
 pub struct FeaturizerConfiguration {
     pub sublinear_tf: bool,
     pub word_clusters_name: Option<String>,
-    pub use_stemming: bool
+    pub use_stemming: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/snips-nlu-lib/src/models/intent_classifier.rs
+++ b/snips-nlu-lib/src/models/intent_classifier.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use utils::IntentName;
+use crate::utils::IntentName;
 
 #[derive(Debug, Deserialize)]
 pub struct IntentClassifierModel {

--- a/snips-nlu-lib/src/models/intent_parser.rs
+++ b/snips-nlu-lib/src/models/intent_parser.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use utils::{EntityName, IntentName, SlotName};
+use crate::utils::{EntityName, IntentName, SlotName};
 
 #[derive(Debug, Deserialize)]
 pub struct DeterministicParserModel {

--- a/snips-nlu-lib/src/models/intent_parser.rs
+++ b/snips-nlu-lib/src/models/intent_parser.rs
@@ -8,13 +8,13 @@ pub struct DeterministicParserModel {
     pub patterns: HashMap<IntentName, Vec<String>>,
     pub group_names_to_slot_names: HashMap<String, SlotName>,
     pub slot_names_to_entities: HashMap<IntentName, HashMap<SlotName, EntityName>>,
-    pub config: DeterministicParserConfig
+    pub config: DeterministicParserConfig,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct DeterministicParserConfig {
     #[serde(default)]
-    pub ignore_stop_words: bool
+    pub ignore_stop_words: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/snips-nlu-lib/src/models/mod.rs
+++ b/snips-nlu-lib/src/models/mod.rs
@@ -1,11 +1,11 @@
 pub mod intent_classifier;
 pub mod intent_parser;
 pub mod nlu_engine;
-pub mod slot_filler;
 pub mod processing_unit_metadata;
+pub mod slot_filler;
 
 pub use self::intent_classifier::*;
 pub use self::intent_parser::*;
 pub use self::nlu_engine::*;
-pub use self::slot_filler::*;
 pub use self::processing_unit_metadata::*;
+pub use self::slot_filler::*;

--- a/snips-nlu-lib/src/models/nlu_engine.rs
+++ b/snips-nlu-lib/src/models/nlu_engine.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
-use utils::{EntityName, IntentName, SlotName};
+
+use crate::utils::{EntityName, IntentName, SlotName};
 
 #[derive(Debug, Deserialize)]
 pub struct ModelVersion {

--- a/snips-nlu-lib/src/models/slot_filler.rs
+++ b/snips-nlu-lib/src/models/slot_filler.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use utils::{EntityName, IntentName, SlotName};
+use crate::utils::{EntityName, IntentName, SlotName};
 
 #[derive(Debug, Deserialize)]
 pub struct SlotFillerModel {
@@ -21,5 +21,5 @@ pub struct SlotFillerConfiguration {
 pub struct FeatureFactory {
     pub factory_name: String,
     pub offsets: Vec<i32>,
-    pub args: HashMap<String, ::serde_json::Value>,
+    pub args: HashMap<String, serde_json::Value>,
 }

--- a/snips-nlu-lib/src/nlu_engine.rs
+++ b/snips-nlu-lib/src/nlu_engine.rs
@@ -6,20 +6,19 @@ use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use entity_parser::{BuiltinEntityParser, CustomEntityParser};
-use errors::*;
 use failure::ResultExt;
-use intent_parser::*;
 use itertools::Itertools;
-use models::{DatasetMetadata, Entity, ModelVersion, NluEngineModel, ProcessingUnitMetadata};
-use nlu_utils::string::substring_with_char_range;
-use resources::loading::load_shared_resources;
-use resources::SharedResources;
-use slot_utils::*;
-use serde_json;
 use snips_nlu_ontology::{BuiltinEntityKind, IntentParserResult, Language, Slot, SlotValue};
-use tempfile;
-use utils::{EntityName, IntentName, SlotName, extract_nlu_engine_zip_archive};
+
+use crate::entity_parser::{BuiltinEntityParser, CustomEntityParser};
+use crate::errors::*;
+use crate::intent_parser::*;
+use crate::models::{DatasetMetadata, Entity, ModelVersion, NluEngineModel, ProcessingUnitMetadata};
+use crate::nlu_utils::string::substring_with_char_range;
+use crate::resources::loading::load_shared_resources;
+use crate::resources::SharedResources;
+use crate::slot_utils::*;
+use crate::utils::{EntityName, IntentName, SlotName, extract_nlu_engine_zip_archive};
 
 pub struct SnipsNluEngine {
     dataset_metadata: DatasetMetadata,
@@ -52,11 +51,11 @@ impl SnipsNluEngine {
     fn check_model_version<P: AsRef<Path>>(path: P) -> Result<()> {
         let model_file = fs::File::open(&path)?;
 
-        let model_version: ModelVersion = ::serde_json::from_reader(model_file)?;
-        if model_version.model_version != ::MODEL_VERSION {
+        let model_version: ModelVersion = serde_json::from_reader(model_file)?;
+        if model_version.model_version != crate::MODEL_VERSION {
             bail!(SnipsNluError::WrongModelVersion(
                 model_version.model_version,
-                ::MODEL_VERSION
+                crate::MODEL_VERSION
             ));
         }
         Ok(())
@@ -300,10 +299,10 @@ fn extract_builtin_slot(
 
 #[cfg(test)]
 mod tests {
+    use crate::entity_parser::custom_entity_parser::CustomEntity;
+    use crate::testutils::*;
     use snips_nlu_ontology::NumberValue;
     use super::*;
-    use entity_parser::custom_entity_parser::CustomEntity;
-    use testutils::*;
 
     #[test]
     fn from_path_works() {

--- a/snips-nlu-lib/src/nlu_engine.rs
+++ b/snips-nlu-lib/src/nlu_engine.rs
@@ -177,7 +177,7 @@ impl SnipsNluEngine {
                         Some(&*builtin_entity_scope),
                         Some(&*custom_entity_scope),
                     )
-                    .with_context(|_| format!("Cannot resolve slots"))?;
+                    .with_context(|_| "Cannot resolve slots".to_string())?;
 
                 return Ok(IntentParserResult {
                     input: input.to_string(),

--- a/snips-nlu-lib/src/nlu_engine.rs
+++ b/snips-nlu-lib/src/nlu_engine.rs
@@ -13,12 +13,14 @@ use snips_nlu_ontology::{BuiltinEntityKind, IntentParserResult, Language, Slot, 
 use crate::entity_parser::{BuiltinEntityParser, CustomEntityParser};
 use crate::errors::*;
 use crate::intent_parser::*;
-use crate::models::{DatasetMetadata, Entity, ModelVersion, NluEngineModel, ProcessingUnitMetadata};
+use crate::models::{
+    DatasetMetadata, Entity, ModelVersion, NluEngineModel, ProcessingUnitMetadata,
+};
 use crate::nlu_utils::string::substring_with_char_range;
 use crate::resources::loading::load_shared_resources;
 use crate::resources::SharedResources;
 use crate::slot_utils::*;
-use crate::utils::{EntityName, IntentName, SlotName, extract_nlu_engine_zip_archive};
+use crate::utils::{extract_nlu_engine_zip_archive, EntityName, IntentName, SlotName};
 
 pub struct SnipsNluEngine {
     dataset_metadata: DatasetMetadata,
@@ -36,10 +38,10 @@ impl SnipsNluEngine {
         let builtin_parser_path = path.as_ref().join(&model.builtin_entity_parser);
         let custom_parser_path = path.as_ref().join(&model.custom_entity_parser);
 
-        let shared_resources = load_shared_resources(&resources_path, builtin_parser_path, custom_parser_path)?;
+        let shared_resources =
+            load_shared_resources(&resources_path, builtin_parser_path, custom_parser_path)?;
 
-        let parsers = Self::load_intent_parsers(
-            path, &model, shared_resources.clone())?;
+        let parsers = Self::load_intent_parsers(path, &model, shared_resources.clone())?;
 
         Ok(SnipsNluEngine {
             dataset_metadata: model.dataset_metadata,
@@ -63,9 +65,9 @@ impl SnipsNluEngine {
 
     fn load_model<P: AsRef<Path>>(path: &P) -> Result<NluEngineModel> {
         let engine_model_path = path.as_ref().join("nlu_engine.json");
-        Self::check_model_version(&engine_model_path)
-            .with_context(|_|
-                SnipsNluError::ModelLoad(engine_model_path.to_str().unwrap().to_string()))?;
+        Self::check_model_version(&engine_model_path).with_context(|_| {
+            SnipsNluError::ModelLoad(engine_model_path.to_str().unwrap().to_string())
+        })?;
         let model_file = fs::File::open(&engine_model_path)
             .with_context(|_| format!("Could not open nlu engine file {:?}", &engine_model_path))?;
         let model = serde_json::from_reader(model_file)
@@ -84,12 +86,16 @@ impl SnipsNluEngine {
             .map(|parser_name| {
                 let parser_path = engine_dir.as_ref().join(parser_name);
                 let metadata_path = parser_path.join("metadata.json");
-                let metadata_file = fs::File::open(metadata_path)
-                    .with_context(|_|
-                        format!("Could not open metadata file of parser '{}'", parser_name))?;
+                let metadata_file = fs::File::open(metadata_path).with_context(|_| {
+                    format!("Could not open metadata file of parser '{}'", parser_name)
+                })?;
                 let metadata: ProcessingUnitMetadata = serde_json::from_reader(metadata_file)
-                    .with_context(|_|
-                        format!("Could not deserialize json metadata of parser '{}'", parser_name))?;
+                    .with_context(|_| {
+                        format!(
+                            "Could not deserialize json metadata of parser '{}'",
+                            parser_name
+                        )
+                    })?;
                 Ok(build_intent_parser(metadata, parser_path, shared_resources.clone())? as _)
             })
             .collect::<Result<Vec<_>>>()
@@ -103,8 +109,7 @@ impl SnipsNluEngine {
         shared_resources: Arc<SharedResources>,
     ) -> Result<Self> {
         let model = SnipsNluEngine::load_model(&path)?;
-        let parsers = Self::load_intent_parsers(
-            path, &model, shared_resources.clone())?;
+        let parsers = Self::load_intent_parsers(path, &model, shared_resources.clone())?;
 
         Ok(SnipsNluEngine {
             dataset_metadata: model.dataset_metadata,
@@ -116,9 +121,7 @@ impl SnipsNluEngine {
 
 impl SnipsNluEngine {
     pub fn from_zip<R: io::Read + io::Seek>(reader: R) -> Result<Self> {
-        let temp_dir = tempfile::Builder::new()
-            .prefix("temp_dir_nlu_")
-            .tempdir()?;
+        let temp_dir = tempfile::Builder::new().prefix("temp_dir_nlu_").tempdir()?;
         let temp_dir_path = temp_dir.path();
         let engine_dir_path = extract_nlu_engine_zip_archive(reader, temp_dir_path)?;
         Ok(SnipsNluEngine::from_path(engine_dir_path)?)
@@ -145,27 +148,36 @@ impl SnipsNluEngine {
             let opt_internal_parsing_result = parser.parse(input, set_intents.as_ref())?;
             if let Some(internal_parsing_result) = opt_internal_parsing_result {
                 let intent = internal_parsing_result.intent;
-                let builtin_entity_scope = self.dataset_metadata
+                let builtin_entity_scope = self
+                    .dataset_metadata
                     .slot_name_mappings
                     .get(&intent.intent_name)
-                    .ok_or_else(|| format_err!("Cannot find intent '{}' in dataset metadata", &intent.intent_name))?
+                    .ok_or_else(|| {
+                        format_err!(
+                            "Cannot find intent '{}' in dataset metadata",
+                            &intent.intent_name
+                        )
+                    })?
                     .values()
                     .flat_map(|entity_name| BuiltinEntityKind::from_identifier(entity_name).ok())
                     .unique()
                     .collect::<Vec<_>>();
 
-                let custom_entity_scope: Vec<String> = self.dataset_metadata
+                let custom_entity_scope: Vec<String> = self
+                    .dataset_metadata
                     .entities
                     .keys()
                     .map(|entity| entity.to_string())
                     .collect();
 
-                let resolved_slots = self.resolve_slots(
-                    input,
-                    internal_parsing_result.slots,
-                    Some(&*builtin_entity_scope),
-                    Some(&*custom_entity_scope),
-                ).with_context(|_| format!("Cannot resolve slots"))?;
+                let resolved_slots = self
+                    .resolve_slots(
+                        input,
+                        internal_parsing_result.slots,
+                        Some(&*builtin_entity_scope),
+                        Some(&*custom_entity_scope),
+                    )
+                    .with_context(|_| format!("Cannot resolve slots"))?;
 
                 return Ok(IntentParserResult {
                     input: input.to_string(),
@@ -188,25 +200,32 @@ impl SnipsNluEngine {
         builtin_entity_filter: Option<&[BuiltinEntityKind]>,
         custom_entity_filter: Option<&[EntityName]>,
     ) -> Result<Vec<Slot>> {
-        let builtin_entities = self.shared_resources.builtin_entity_parser
+        let builtin_entities = self
+            .shared_resources
+            .builtin_entity_parser
             .extract_entities(text, builtin_entity_filter, false)?;
-        let custom_entities = self.shared_resources.custom_entity_parser
+        let custom_entities = self
+            .shared_resources
+            .custom_entity_parser
             .extract_entities(text, custom_entity_filter)?;
 
         let mut resolved_slots = Vec::with_capacity(slots.len());
         for slot in slots.into_iter() {
-            let opt_resolved_slot = if let Some(entity) = self.dataset_metadata.entities.get(&slot.entity) {
-                resolve_custom_slot(
-                    slot,
-                    &entity,
-                    &custom_entities,
-                    self.shared_resources.custom_entity_parser.clone())?
-            } else {
-                resolve_builtin_slot(
-                    slot,
-                    &builtin_entities,
-                    self.shared_resources.builtin_entity_parser.clone())?
-            };
+            let opt_resolved_slot =
+                if let Some(entity) = self.dataset_metadata.entities.get(&slot.entity) {
+                    resolve_custom_slot(
+                        slot,
+                        &entity,
+                        &custom_entities,
+                        self.shared_resources.custom_entity_parser.clone(),
+                    )?
+                } else {
+                    resolve_builtin_slot(
+                        slot,
+                        &builtin_entities,
+                        self.shared_resources.builtin_entity_parser.clone(),
+                    )?
+                };
             if let Some(resolved_slot) = opt_resolved_slot {
                 resolved_slots.push(resolved_slot);
             }
@@ -222,7 +241,8 @@ impl SnipsNluEngine {
         intent_name: &str,
         slot_name: &str,
     ) -> Result<Option<Slot>> {
-        let entity_name = self.dataset_metadata
+        let entity_name = self
+            .dataset_metadata
             .slot_name_mappings
             .get(intent_name)
             .ok_or_else(|| format_err!("Unknown intent: {}", intent_name))?
@@ -235,13 +255,15 @@ impl SnipsNluEngine {
                 entity_name.to_string(),
                 slot_name.to_string(),
                 custom_entity,
-                self.shared_resources.custom_entity_parser.clone())?
+                self.shared_resources.custom_entity_parser.clone(),
+            )?
         } else {
             extract_builtin_slot(
                 input,
                 entity_name.to_string(),
                 slot_name.to_string(),
-                self.shared_resources.builtin_entity_parser.clone())?
+                self.shared_resources.builtin_entity_parser.clone(),
+            )?
         };
         Ok(slot)
     }
@@ -254,7 +276,8 @@ fn extract_custom_slot(
     custom_entity: &Entity,
     custom_entity_parser: Arc<CustomEntityParser>,
 ) -> Result<Option<Slot>> {
-    let mut custom_entities = custom_entity_parser.extract_entities(&input, Some(&[entity_name.clone()]))?;
+    let mut custom_entities =
+        custom_entity_parser.extract_entities(&input, Some(&[entity_name.clone()]))?;
     Ok(if let Some(matched_entity) = custom_entities.pop() {
         Some(Slot {
             raw_value: matched_entity.value,
@@ -296,20 +319,17 @@ fn extract_builtin_slot(
         }))
 }
 
-
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::entity_parser::custom_entity_parser::CustomEntity;
     use crate::testutils::*;
     use snips_nlu_ontology::NumberValue;
-    use super::*;
 
     #[test]
     fn from_path_works() {
         // Given
-        let path = file_path("tests")
-            .join("models")
-            .join("nlu_engine");
+        let path = file_path("tests").join("models").join("nlu_engine");
 
         // When / Then
         let nlu_engine = SnipsNluEngine::from_path(path);
@@ -319,9 +339,7 @@ mod tests {
     #[test]
     fn from_zip_works() {
         // Given
-        let path = file_path("tests")
-            .join("models")
-            .join("nlu_engine.zip");
+        let path = file_path("tests").join("models").join("nlu_engine.zip");
 
         let file = fs::File::open(path).unwrap();
 
@@ -337,27 +355,26 @@ mod tests {
             .unwrap();
 
         let expected_entity_value = SlotValue::Number(NumberValue { value: 2.0 });
-        let expected_slots = Some(vec![
-            Slot {
-                raw_value: "two".to_string(),
-                value: expected_entity_value,
-                range: Some(8..11),
-                entity: "snips/number".to_string(),
-                slot_name: "number_of_cups".to_string(),
-            },
-        ]);
+        let expected_slots = Some(vec![Slot {
+            raw_value: "two".to_string(),
+            value: expected_entity_value,
+            range: Some(8..11),
+            entity: "snips/number".to_string(),
+            slot_name: "number_of_cups".to_string(),
+        }]);
         let expected_intent = Some("MakeCoffee".to_string());
 
-        assert_eq!(expected_intent, result.intent.map(|intent| intent.intent_name));
+        assert_eq!(
+            expected_intent,
+            result.intent.map(|intent| intent.intent_name)
+        );
         assert_eq!(expected_slots, result.slots);
     }
 
     #[test]
     fn parse_works() {
         // Given
-        let path = file_path("tests")
-            .join("models")
-            .join("nlu_engine");
+        let path = file_path("tests").join("models").join("nlu_engine");
         let nlu_engine = SnipsNluEngine::from_path(path).unwrap();
 
         // When
@@ -367,18 +384,19 @@ mod tests {
 
         // Then
         let expected_entity_value = SlotValue::Number(NumberValue { value: 2.0 });
-        let expected_slots = Some(vec![
-            Slot {
-                raw_value: "two".to_string(),
-                value: expected_entity_value,
-                range: Some(8..11),
-                entity: "snips/number".to_string(),
-                slot_name: "number_of_cups".to_string(),
-            },
-        ]);
+        let expected_slots = Some(vec![Slot {
+            raw_value: "two".to_string(),
+            value: expected_entity_value,
+            range: Some(8..11),
+            entity: "snips/number".to_string(),
+            slot_name: "number_of_cups".to_string(),
+        }]);
         let expected_intent = Some("MakeCoffee".to_string());
 
-        assert_eq!(expected_intent, result.intent.map(|intent| intent.intent_name));
+        assert_eq!(
+            expected_intent,
+            result.intent.map(|intent| intent.intent_name)
+        );
         assert_eq!(expected_slots, result.slots);
     }
 
@@ -392,29 +410,33 @@ mod tests {
             automatically_extensible: true,
         };
 
-        let mocked_custom_parser = Arc::new(MockedCustomEntityParser::from_iter(
-            vec![(
-                "hello a b c d world".to_string(),
-                vec![
-                    CustomEntity {
-                        value: "a b".to_string(),
-                        resolved_value: "value1".to_string(),
-                        range: 6..9,
-                        entity_identifier: entity_name.to_string(),
-                    },
-                    CustomEntity {
-                        value: "b c d".to_string(),
-                        resolved_value: "value2".to_string(),
-                        range: 8..13,
-                        entity_identifier: entity_name.to_string(),
-                    }
-                ]
-            )]
-        ));
+        let mocked_custom_parser = Arc::new(MockedCustomEntityParser::from_iter(vec![(
+            "hello a b c d world".to_string(),
+            vec![
+                CustomEntity {
+                    value: "a b".to_string(),
+                    resolved_value: "value1".to_string(),
+                    range: 6..9,
+                    entity_identifier: entity_name.to_string(),
+                },
+                CustomEntity {
+                    value: "b c d".to_string(),
+                    resolved_value: "value2".to_string(),
+                    range: 8..13,
+                    entity_identifier: entity_name.to_string(),
+                },
+            ],
+        )]));
 
         // When
         let extracted_slot = extract_custom_slot(
-            input, entity_name, slot_name, &custom_entity, mocked_custom_parser).unwrap();
+            input,
+            entity_name,
+            slot_name,
+            &custom_entity,
+            mocked_custom_parser,
+        )
+        .unwrap();
 
         // Then
         let expected_slot = Some(Slot {
@@ -441,7 +463,13 @@ mod tests {
 
         // When
         let extracted_slot = extract_custom_slot(
-            input, entity_name, slot_name, &custom_entity, mocked_custom_parser).unwrap();
+            input,
+            entity_name,
+            slot_name,
+            &custom_entity,
+            mocked_custom_parser,
+        )
+        .unwrap();
 
         // Then
         let expected_slot = Some(Slot {
@@ -468,7 +496,13 @@ mod tests {
 
         // When
         let extracted_slot = extract_custom_slot(
-            input, entity_name, slot_name, &custom_entity, mocked_custom_parser).unwrap();
+            input,
+            entity_name,
+            slot_name,
+            &custom_entity,
+            mocked_custom_parser,
+        )
+        .unwrap();
 
         // Then
         let expected_slot = None;

--- a/snips-nlu-lib/src/resources/gazetteer.rs
+++ b/snips-nlu-lib/src/resources/gazetteer.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::io::{BufRead, BufReader, Read};
 use std::iter::FromIterator;
 
-use errors::*;
+use crate::errors::*;
 
 pub trait Gazetteer: Send + Sync {
     fn contains(&self, value: &str) -> bool;

--- a/snips-nlu-lib/src/resources/gazetteer.rs
+++ b/snips-nlu-lib/src/resources/gazetteer.rs
@@ -27,8 +27,10 @@ impl HashSetGazetteer {
 }
 
 impl FromIterator<String> for HashSetGazetteer {
-    fn from_iter<T: IntoIterator<Item=String>>(iter: T) -> Self {
-        Self { values: HashSet::from_iter(iter) }
+    fn from_iter<T: IntoIterator<Item = String>>(iter: T) -> Self {
+        Self {
+            values: HashSet::from_iter(iter),
+        }
     }
 }
 
@@ -49,7 +51,8 @@ mod tests {
 dog
 cat
 bear
-crocodile"#.as_ref();
+crocodile"#
+            .as_ref();
 
         // When
         let gazetteer = HashSetGazetteer::from_reader(gazetteer);

--- a/snips-nlu-lib/src/resources/loading.rs
+++ b/snips-nlu-lib/src/resources/loading.rs
@@ -5,17 +5,16 @@ use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use serde_json;
+use failure::ResultExt;
 use snips_nlu_ontology::Language;
 
-use entity_parser::{CachingBuiltinEntityParser, CachingCustomEntityParser};
-use errors::*;
-use failure::ResultExt;
-use models::nlu_engine::NluEngineModel;
-use resources::SharedResources;
-use resources::gazetteer::{Gazetteer, HashSetGazetteer};
-use resources::word_clusterer::{HashMapWordClusterer, WordClusterer};
-use resources::stemmer::{HashMapStemmer, Stemmer};
+use crate::entity_parser::{CachingBuiltinEntityParser, CachingCustomEntityParser};
+use crate::errors::*;
+use crate::models::nlu_engine::NluEngineModel;
+use crate::resources::SharedResources;
+use crate::resources::gazetteer::{Gazetteer, HashSetGazetteer};
+use crate::resources::word_clusterer::{HashMapWordClusterer, WordClusterer};
+use crate::resources::stemmer::{HashMapStemmer, Stemmer};
 
 #[derive(Debug, Deserialize, Clone)]
 struct ResourcesMetadata {

--- a/snips-nlu-lib/src/resources/mod.rs
+++ b/snips-nlu-lib/src/resources/mod.rs
@@ -1,5 +1,5 @@
-pub mod loading;
 pub mod gazetteer;
+pub mod loading;
 pub mod stemmer;
 pub mod word_clusterer;
 
@@ -17,5 +17,5 @@ pub struct SharedResources {
     pub gazetteers: HashMap<String, Arc<Gazetteer>>,
     pub stemmer: Option<Arc<Stemmer>>,
     pub word_clusterers: HashMap<String, Arc<WordClusterer>>,
-    pub stop_words: HashSet<String>
+    pub stop_words: HashSet<String>,
 }

--- a/snips-nlu-lib/src/resources/mod.rs
+++ b/snips-nlu-lib/src/resources/mod.rs
@@ -6,10 +6,10 @@ pub mod word_clusterer;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use entity_parser::{BuiltinEntityParser, CustomEntityParser};
-use resources::gazetteer::Gazetteer;
-use resources::stemmer::Stemmer;
-use resources::word_clusterer::WordClusterer;
+use self::gazetteer::Gazetteer;
+use self::stemmer::Stemmer;
+use self::word_clusterer::WordClusterer;
+use super::entity_parser::{BuiltinEntityParser, CustomEntityParser};
 
 pub struct SharedResources {
     pub builtin_entity_parser: Arc<BuiltinEntityParser>,

--- a/snips-nlu-lib/src/resources/stemmer.rs
+++ b/snips-nlu-lib/src/resources/stemmer.rs
@@ -2,9 +2,9 @@ use std::collections::HashMap;
 use std::io::Read;
 use std::iter::FromIterator;
 
-use csv;
-use errors::*;
 use nlu_utils::string::normalize;
+
+use crate::errors::*;
 
 pub trait Stemmer: Send + Sync {
     fn stem(&self, value: &str) -> String;

--- a/snips-nlu-lib/src/resources/stemmer.rs
+++ b/snips-nlu-lib/src/resources/stemmer.rs
@@ -11,7 +11,7 @@ pub trait Stemmer: Send + Sync {
 }
 
 pub struct HashMapStemmer {
-    values: HashMap<String, String>
+    values: HashMap<String, String>,
 }
 
 impl HashMapStemmer {
@@ -36,8 +36,10 @@ impl HashMapStemmer {
 }
 
 impl FromIterator<(String, String)> for HashMapStemmer {
-    fn from_iter<T: IntoIterator<Item=(String, String)>>(iter: T) -> Self {
-        Self { values: HashMap::from_iter(iter) }
+    fn from_iter<T: IntoIterator<Item = (String, String)>>(iter: T) -> Self {
+        Self {
+            values: HashMap::from_iter(iter),
+        }
     }
 }
 
@@ -59,7 +61,8 @@ mod tests {
         // Given
         let stems: &[u8] = r#"
 investigate,investigated,investigation,"investigate
-do,done,don't,doing,did,does"#.as_ref();
+do,done,don't,doing,did,does"#
+            .as_ref();
 
         // When
         let stemmer = HashMapStemmer::from_reader(stems);

--- a/snips-nlu-lib/src/resources/word_clusterer.rs
+++ b/snips-nlu-lib/src/resources/word_clusterer.rs
@@ -11,7 +11,7 @@ pub trait WordClusterer: Send + Sync {
 }
 
 pub struct HashMapWordClusterer {
-    values: HashMap<String, String>
+    values: HashMap<String, String>,
 }
 
 impl HashMapWordClusterer {
@@ -32,16 +32,16 @@ impl HashMapWordClusterer {
 }
 
 impl FromIterator<(String, String)> for HashMapWordClusterer {
-    fn from_iter<T: IntoIterator<Item=(String, String)>>(iter: T) -> Self {
-        Self { values: HashMap::from_iter(iter) }
+    fn from_iter<T: IntoIterator<Item = (String, String)>>(iter: T) -> Self {
+        Self {
+            values: HashMap::from_iter(iter),
+        }
     }
 }
 
 impl WordClusterer for HashMapWordClusterer {
     fn get_cluster(&self, word: &str) -> Option<String> {
-        self.values
-            .get(word)
-            .map(|v| v.to_string())
+        self.values.get(word).map(|v| v.to_string())
     }
 }
 
@@ -50,7 +50,6 @@ pub struct WordClustererConfiguration {
     language: Language,
     clusters_name: String,
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -63,7 +62,8 @@ mod tests {
 hello	1111111111111
 world	1111110111111
 "yolo	1111100111111
-"#.as_ref();
+"#
+        .as_ref();
 
         // When
         let clusterer = HashMapWordClusterer::from_reader(clusters);
@@ -71,9 +71,18 @@ world	1111110111111
         // Then
         assert!(clusterer.is_ok());
         let clusterer = clusterer.unwrap();
-        assert_eq!(clusterer.get_cluster("hello"), Some("1111111111111".to_string()));
-        assert_eq!(clusterer.get_cluster("world"), Some("1111110111111".to_string()));
-        assert_eq!(clusterer.get_cluster("\"yolo"), Some("1111100111111".to_string()));
+        assert_eq!(
+            clusterer.get_cluster("hello"),
+            Some("1111111111111".to_string())
+        );
+        assert_eq!(
+            clusterer.get_cluster("world"),
+            Some("1111110111111".to_string())
+        );
+        assert_eq!(
+            clusterer.get_cluster("\"yolo"),
+            Some("1111100111111".to_string())
+        );
         assert_eq!(clusterer.get_cluster("unknown"), None);
     }
 }

--- a/snips-nlu-lib/src/resources/word_clusterer.rs
+++ b/snips-nlu-lib/src/resources/word_clusterer.rs
@@ -2,9 +2,9 @@ use std::collections::HashMap;
 use std::io::Read;
 use std::iter::FromIterator;
 
-use csv;
-use errors::*;
 use snips_nlu_ontology::Language;
+
+use crate::errors::*;
 
 pub trait WordClusterer: Send + Sync {
     fn get_cluster(&self, word: &str) -> Option<String>;

--- a/snips-nlu-lib/src/slot_filler/crf_slot_filler.rs
+++ b/snips-nlu-lib/src/slot_filler/crf_slot_filler.rs
@@ -164,7 +164,7 @@ impl SlotFiller for CRFSlotFiller {
                 .map(|t| encode_tag(t))
                 .collect_vec();
             tagger.set(&features)?;
-            Ok(tagger.probability(cleaned_tags)?)
+            Ok(tagger.probability(&cleaned_tags)?)
         } else {
             // No tagger defined corresponds to an intent without slots
             Ok(tags.into_iter()

--- a/snips-nlu-lib/src/slot_filler/crf_slot_filler.rs
+++ b/snips-nlu-lib/src/slot_filler/crf_slot_filler.rs
@@ -7,25 +7,24 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
 use crfsuite::Tagger as CRFSuiteTagger;
-use itertools::Itertools;
-
-use entity_parser::BuiltinEntityParser;
-use errors::*;
 use failure::ResultExt;
-use language::FromLanguage;
-use models::SlotFillerModel;
+use itertools::Itertools;
 use nlu_utils::language::Language as NluUtilsLanguage;
 use nlu_utils::range::ranges_overlap;
 use nlu_utils::string::substring_with_char_range;
 use nlu_utils::token::{tokenize, Token};
-use resources::SharedResources;
-use serde_json;
-use slot_filler::crf_utils::*;
-use slot_filler::feature_processor::ProbabilisticFeatureProcessor;
-use slot_filler::SlotFiller;
-use slot_utils::*;
 use snips_nlu_ontology::{BuiltinEntity, BuiltinEntityKind, Language};
-use utils::{EntityName, SlotName};
+
+use crate::entity_parser::BuiltinEntityParser;
+use crate::errors::*;
+use crate::language::FromLanguage;
+use crate::models::SlotFillerModel;
+use crate::resources::SharedResources;
+use crate::slot_filler::crf_utils::*;
+use crate::slot_filler::feature_processor::ProbabilisticFeatureProcessor;
+use crate::slot_filler::SlotFiller;
+use crate::slot_utils::*;
+use crate::utils::{EntityName, SlotName};
 
 pub struct CRFSlotFiller {
     language: Language,
@@ -194,12 +193,12 @@ impl CRFSlotFiller {
 // python-crfsuite
 
 fn decode_tag(tag: &str) -> Result<String> {
-    let bytes = ::base64::decode(tag)?;
+    let bytes = base64::decode(tag)?;
     Ok(String::from_utf8(bytes)?)
 }
 
 fn encode_tag(tag: &str) -> String {
-    ::base64::encode(tag)
+    base64::encode(tag)
 }
 
 fn filter_overlapping_builtins(
@@ -393,10 +392,12 @@ fn spans_to_tokens_indexes(spans: &[Range<usize>], tokens: &[Token]) -> Vec<Vec<
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use nlu_utils::language::Language as NluUtilsLanguage;
-    use resources::loading::load_engine_shared_resources;
     use snips_nlu_ontology::*;
-    use testutils::*;
+
+    use crate::resources::loading::load_engine_shared_resources;
+    use crate::testutils::*;
 
     #[derive(Debug, Fail)]
     pub enum TestError {

--- a/snips-nlu-lib/src/slot_filler/crf_utils.rs
+++ b/snips-nlu-lib/src/slot_filler/crf_utils.rs
@@ -2,13 +2,13 @@ use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 
 use itertools::Itertools;
-
-use errors::*;
-use nlu_utils::string::suffix_from_char_index;
-use nlu_utils::token::Token;
-use slot_utils::InternalSlot;
-use utils::{EntityName, product, SlotName};
 use snips_nlu_ontology::BuiltinEntity;
+
+use crate::errors::*;
+use crate::nlu_utils::string::suffix_from_char_index;
+use crate::nlu_utils::token::Token;
+use crate::slot_utils::InternalSlot;
+use crate::utils::{EntityName, product, SlotName};
 
 const BEGINNING_PREFIX: &str = "B-";
 const INSIDE_PREFIX: &str = "I-";

--- a/snips-nlu-lib/src/slot_filler/crf_utils.rs
+++ b/snips-nlu-lib/src/slot_filler/crf_utils.rs
@@ -8,7 +8,7 @@ use crate::errors::*;
 use crate::nlu_utils::string::suffix_from_char_index;
 use crate::nlu_utils::token::Token;
 use crate::slot_utils::InternalSlot;
-use crate::utils::{EntityName, product, SlotName};
+use crate::utils::{product, EntityName, SlotName};
 
 const BEGINNING_PREFIX: &str = "B-";
 const INSIDE_PREFIX: &str = "I-";
@@ -164,9 +164,9 @@ fn _tags_to_slots<F1, F2>(
     is_start_of_slot: F1,
     is_end_of_slot: F2,
 ) -> Vec<SlotRange>
-    where
-        F1: Fn(&[String], usize) -> bool,
-        F2: Fn(&[String], usize) -> bool,
+where
+    F1: Fn(&[String], usize) -> bool,
+    F2: Fn(&[String], usize) -> bool,
 {
     let mut slots: Vec<SlotRange> = Vec::with_capacity(tags.len());
 
@@ -364,14 +364,12 @@ mod tests {
                     format!("{}{}", INSIDE_PREFIX, slot_name),
                     format!("{}{}", INSIDE_PREFIX, slot_name),
                 ],
-                expected_slots: vec![
-                    InternalSlot {
-                        char_range: 7..16,
-                        value: "blue bird".to_string(),
-                        entity: slot_name.to_string(),
-                        slot_name: slot_name.to_string(),
-                    },
-                ],
+                expected_slots: vec![InternalSlot {
+                    char_range: 7..16,
+                    value: "blue bird".to_string(),
+                    entity: slot_name.to_string(),
+                    slot_name: slot_name.to_string(),
+                }],
             },
             Test {
                 text: "i am a bird".to_string(),
@@ -381,26 +379,22 @@ mod tests {
                     OUTSIDE.to_string(),
                     format!("{}{}", INSIDE_PREFIX, slot_name),
                 ],
-                expected_slots: vec![
-                    InternalSlot {
-                        char_range: 7..11,
-                        value: "bird".to_string(),
-                        entity: slot_name.to_string(),
-                        slot_name: slot_name.to_string(),
-                    },
-                ],
+                expected_slots: vec![InternalSlot {
+                    char_range: 7..11,
+                    value: "bird".to_string(),
+                    entity: slot_name.to_string(),
+                    slot_name: slot_name.to_string(),
+                }],
             },
             Test {
                 text: "bird".to_string(),
                 tags: vec![format!("{}{}", INSIDE_PREFIX, slot_name)],
-                expected_slots: vec![
-                    InternalSlot {
-                        char_range: 0..4,
-                        value: "bird".to_string(),
-                        entity: slot_name.to_string(),
-                        slot_name: slot_name.to_string(),
-                    },
-                ],
+                expected_slots: vec![InternalSlot {
+                    char_range: 0..4,
+                    value: "bird".to_string(),
+                    entity: slot_name.to_string(),
+                    slot_name: slot_name.to_string(),
+                }],
             },
             Test {
                 text: "blue bird".to_string(),
@@ -408,14 +402,12 @@ mod tests {
                     format!("{}{}", INSIDE_PREFIX, slot_name),
                     format!("{}{}", INSIDE_PREFIX, slot_name),
                 ],
-                expected_slots: vec![
-                    InternalSlot {
-                        char_range: 0..9,
-                        value: "blue bird".to_string(),
-                        entity: slot_name.to_string(),
-                        slot_name: slot_name.to_string(),
-                    },
-                ],
+                expected_slots: vec![InternalSlot {
+                    char_range: 0..9,
+                    value: "blue bird".to_string(),
+                    entity: slot_name.to_string(),
+                    slot_name: slot_name.to_string(),
+                }],
             },
             Test {
                 text: "light blue bird blue bird".to_string(),
@@ -426,14 +418,12 @@ mod tests {
                     format!("{}{}", INSIDE_PREFIX, slot_name),
                     format!("{}{}", INSIDE_PREFIX, slot_name),
                 ],
-                expected_slots: vec![
-                    InternalSlot {
-                        char_range: 0..25,
-                        value: "light blue bird blue bird".to_string(),
-                        entity: slot_name.to_string(),
-                        slot_name: slot_name.to_string(),
-                    },
-                ],
+                expected_slots: vec![InternalSlot {
+                    char_range: 0..25,
+                    value: "light blue bird blue bird".to_string(),
+                    entity: slot_name.to_string(),
+                    slot_name: slot_name.to_string(),
+                }],
             },
             Test {
                 text: "bird birdy".to_string(),
@@ -441,14 +431,12 @@ mod tests {
                     format!("{}{}", INSIDE_PREFIX, slot_name),
                     format!("{}{}", INSIDE_PREFIX, slot_name),
                 ],
-                expected_slots: vec![
-                    InternalSlot {
-                        char_range: 0..10,
-                        value: "bird birdy".to_string(),
-                        entity: slot_name.to_string(),
-                        slot_name: slot_name.to_string(),
-                    },
-                ],
+                expected_slots: vec![InternalSlot {
+                    char_range: 0..10,
+                    value: "bird birdy".to_string(),
+                    entity: slot_name.to_string(),
+                    slot_name: slot_name.to_string(),
+                }],
             },
         ];
 
@@ -460,7 +448,8 @@ mod tests {
                 &data.tags,
                 TaggingScheme::IO,
                 &intent_slots_mapping,
-            ).unwrap();
+            )
+            .unwrap();
             // Then
             assert_eq!(slots, data.expected_slots);
         }
@@ -492,14 +481,12 @@ mod tests {
                     format!("{}{}", BEGINNING_PREFIX, slot_name),
                     format!("{}{}", INSIDE_PREFIX, slot_name),
                 ],
-                expected_slots: vec![
-                    InternalSlot {
-                        char_range: 7..16,
-                        value: "blue bird".to_string(),
-                        entity: slot_name.to_string(),
-                        slot_name: slot_name.to_string(),
-                    },
-                ],
+                expected_slots: vec![InternalSlot {
+                    char_range: 7..16,
+                    value: "blue bird".to_string(),
+                    entity: slot_name.to_string(),
+                    slot_name: slot_name.to_string(),
+                }],
             },
             Test {
                 text: "i am a bird".to_string(),
@@ -509,26 +496,22 @@ mod tests {
                     OUTSIDE.to_string(),
                     format!("{}{}", BEGINNING_PREFIX, slot_name),
                 ],
-                expected_slots: vec![
-                    InternalSlot {
-                        char_range: 7..11,
-                        value: "bird".to_string(),
-                        entity: slot_name.to_string(),
-                        slot_name: slot_name.to_string(),
-                    },
-                ],
+                expected_slots: vec![InternalSlot {
+                    char_range: 7..11,
+                    value: "bird".to_string(),
+                    entity: slot_name.to_string(),
+                    slot_name: slot_name.to_string(),
+                }],
             },
             Test {
                 text: "bird".to_string(),
                 tags: vec![format!("{}{}", BEGINNING_PREFIX, slot_name)],
-                expected_slots: vec![
-                    InternalSlot {
-                        char_range: 0..4,
-                        value: "bird".to_string(),
-                        entity: slot_name.to_string(),
-                        slot_name: slot_name.to_string(),
-                    },
-                ],
+                expected_slots: vec![InternalSlot {
+                    char_range: 0..4,
+                    value: "bird".to_string(),
+                    entity: slot_name.to_string(),
+                    slot_name: slot_name.to_string(),
+                }],
             },
             Test {
                 text: "blue bird".to_string(),
@@ -536,14 +519,12 @@ mod tests {
                     format!("{}{}", BEGINNING_PREFIX, slot_name),
                     format!("{}{}", INSIDE_PREFIX, slot_name),
                 ],
-                expected_slots: vec![
-                    InternalSlot {
-                        char_range: 0..9,
-                        value: "blue bird".to_string(),
-                        entity: slot_name.to_string(),
-                        slot_name: slot_name.to_string(),
-                    },
-                ],
+                expected_slots: vec![InternalSlot {
+                    char_range: 0..9,
+                    value: "blue bird".to_string(),
+                    entity: slot_name.to_string(),
+                    slot_name: slot_name.to_string(),
+                }],
             },
             Test {
                 text: "light blue bird blue bird".to_string(),
@@ -624,7 +605,8 @@ mod tests {
                 &data.tags,
                 TaggingScheme::BIO,
                 &intent_slots_mapping,
-            ).unwrap();
+            )
+            .unwrap();
             // Then
             assert_eq!(slots, data.expected_slots);
         }
@@ -656,14 +638,12 @@ mod tests {
                     format!("{}{}", BEGINNING_PREFIX, slot_name),
                     format!("{}{}", LAST_PREFIX, slot_name),
                 ],
-                expected_slots: vec![
-                    InternalSlot {
-                        char_range: 7..16,
-                        value: "blue bird".to_string(),
-                        entity: slot_name.to_string(),
-                        slot_name: slot_name.to_string(),
-                    },
-                ],
+                expected_slots: vec![InternalSlot {
+                    char_range: 7..16,
+                    value: "blue bird".to_string(),
+                    entity: slot_name.to_string(),
+                    slot_name: slot_name.to_string(),
+                }],
             },
             Test {
                 text: "i am a bird".to_string(),
@@ -673,26 +653,22 @@ mod tests {
                     OUTSIDE.to_string(),
                     format!("{}{}", UNIT_PREFIX, slot_name),
                 ],
-                expected_slots: vec![
-                    InternalSlot {
-                        char_range: 7..11,
-                        value: "bird".to_string(),
-                        entity: slot_name.to_string(),
-                        slot_name: slot_name.to_string(),
-                    },
-                ],
+                expected_slots: vec![InternalSlot {
+                    char_range: 7..11,
+                    value: "bird".to_string(),
+                    entity: slot_name.to_string(),
+                    slot_name: slot_name.to_string(),
+                }],
             },
             Test {
                 text: "bird".to_string(),
                 tags: vec![format!("{}{}", UNIT_PREFIX, slot_name)],
-                expected_slots: vec![
-                    InternalSlot {
-                        char_range: 0..4,
-                        value: "bird".to_string(),
-                        entity: slot_name.to_string(),
-                        slot_name: slot_name.to_string(),
-                    },
-                ],
+                expected_slots: vec![InternalSlot {
+                    char_range: 0..4,
+                    value: "bird".to_string(),
+                    entity: slot_name.to_string(),
+                    slot_name: slot_name.to_string(),
+                }],
             },
             Test {
                 text: "blue bird".to_string(),
@@ -700,14 +676,12 @@ mod tests {
                     format!("{}{}", BEGINNING_PREFIX, slot_name),
                     format!("{}{}", LAST_PREFIX, slot_name),
                 ],
-                expected_slots: vec![
-                    InternalSlot {
-                        char_range: 0..9,
-                        value: "blue bird".to_string(),
-                        entity: slot_name.to_string(),
-                        slot_name: slot_name.to_string(),
-                    },
-                ],
+                expected_slots: vec![InternalSlot {
+                    char_range: 0..9,
+                    value: "blue bird".to_string(),
+                    entity: slot_name.to_string(),
+                    slot_name: slot_name.to_string(),
+                }],
             },
             Test {
                 text: "light blue bird blue bird".to_string(),
@@ -822,7 +796,8 @@ mod tests {
                 &data.tags,
                 TaggingScheme::BILOU,
                 &intent_slots_mapping,
-            ).unwrap();
+            )
+            .unwrap();
             // Then
             assert_eq!(slots, data.expected_slots);
         }
@@ -850,7 +825,8 @@ mod tests {
         ];
 
         // When
-        let starts_of_bio = tags.iter()
+        let starts_of_bio = tags
+            .iter()
             .enumerate()
             .map(|(i, _)| is_start_of_bio_slot(tags, i))
             .collect_vec();
@@ -886,7 +862,8 @@ mod tests {
         ];
 
         // When
-        let ends_of_bio = tags.iter()
+        let ends_of_bio = tags
+            .iter()
             .enumerate()
             .map(|(i, _)| is_end_of_bio_slot(tags, i))
             .collect_vec();
@@ -924,7 +901,8 @@ mod tests {
         ];
 
         // When
-        let starts_of_bilou = tags.iter()
+        let starts_of_bilou = tags
+            .iter()
             .enumerate()
             .map(|(i, _)| is_start_of_bilou_slot(tags, i))
             .collect_vec();
@@ -964,7 +942,8 @@ mod tests {
         ];
 
         // When
-        let ends_of_bilou = tags.iter()
+        let ends_of_bilou = tags
+            .iter()
             .enumerate()
             .map(|(i, _)| is_end_of_bilou_slot(tags, i))
             .collect_vec();

--- a/snips-nlu-lib/src/slot_filler/crf_utils.rs
+++ b/snips-nlu-lib/src/slot_filler/crf_utils.rs
@@ -295,13 +295,13 @@ pub fn generate_slots_permutations(
     slot_name_mapping: &HashMap<SlotName, EntityName>,
 ) -> Vec<Vec<String>> {
     let possible_slots: Vec<Vec<String>> = grouped_entities
-        .into_iter()
+        .iter()
         .map(|entities| {
             let mut slot_names: Vec<String> = entities
-                .into_iter()
+                .iter()
                 .flat_map::<Vec<String>, _>(|entity| {
                     slot_name_mapping
-                        .into_iter()
+                        .iter()
                         .filter_map(|(slot_name, entity_name)| {
                             if entity_name == entity.entity_kind.identifier() {
                                 Some(slot_name.to_string())

--- a/snips-nlu-lib/src/slot_filler/feature_processor.rs
+++ b/snips-nlu-lib/src/slot_filler/feature_processor.rs
@@ -26,7 +26,9 @@ impl ProbabilisticFeatureProcessor {
             .flat_map(|fs| fs)
             .collect();
 
-        Ok(ProbabilisticFeatureProcessor { features_offsetters })
+        Ok(ProbabilisticFeatureProcessor {
+            features_offsetters,
+        })
     }
 }
 
@@ -53,7 +55,7 @@ impl ProbabilisticFeatureProcessor {
 
 struct FeatureOffsetter {
     feature: Box<Feature>,
-    offsets: Vec<i32>
+    offsets: Vec<i32>,
 }
 
 impl FeatureOffsetter {
@@ -79,11 +81,15 @@ pub trait FeatureKindRepr {
 }
 
 pub trait Feature: FeatureKindRepr + Send + Sync {
-    fn name(&self) -> String { self.feature_kind().identifier().to_string() }
+    fn name(&self) -> String {
+        self.feature_kind().identifier().to_string()
+    }
     fn build_features(
         args: &HashMap<String, serde_json::Value>,
         shared_resources: Arc<SharedResources>,
-    ) -> Result<Vec<Box<Feature>>> where Self: Sized;
+    ) -> Result<Vec<Box<Feature>>>
+    where
+        Self: Sized;
     fn compute(&self, tokens: &[Token], token_index: usize) -> Result<Option<String>>;
 }
 
@@ -116,12 +122,12 @@ mod tests {
             features_offsetters: vec![
                 FeatureOffsetter {
                     offsets: vec![0],
-                    feature: Box::new(IsDigitFeature {}) as Box<_>
+                    feature: Box::new(IsDigitFeature {}) as Box<_>,
                 },
                 FeatureOffsetter {
                     offsets: vec![0],
-                    feature: Box::new(LengthFeature {}) as Box<_>
-                }
+                    feature: Box::new(LengthFeature {}) as Box<_>,
+                },
             ],
         };
         let tokens = tokenize("I prefer 7 over 777", language);
@@ -132,9 +138,15 @@ mod tests {
         let expected_features = vec![
             vec![("length".to_string(), "1".to_string())],
             vec![("length".to_string(), "6".to_string())],
-            vec![("is_digit".to_string(), "1".to_string()), ("length".to_string(), "1".to_string())],
+            vec![
+                ("is_digit".to_string(), "1".to_string()),
+                ("length".to_string(), "1".to_string()),
+            ],
             vec![("length".to_string(), "4".to_string())],
-            vec![("is_digit".to_string(), "1".to_string()), ("length".to_string(), "3".to_string())],
+            vec![
+                ("is_digit".to_string(), "1".to_string()),
+                ("length".to_string(), "3".to_string()),
+            ],
         ];
 
         // Then
@@ -149,11 +161,11 @@ mod tests {
             features_offsetters: vec![
                 FeatureOffsetter {
                     offsets: vec![-2, 0, 3],
-                    feature: Box::new(IsDigitFeature {}) as Box<_>
+                    feature: Box::new(IsDigitFeature {}) as Box<_>,
                 },
                 FeatureOffsetter {
                     offsets: vec![-1, 1],
-                    feature: Box::new(LengthFeature{}) as Box<_>
+                    feature: Box::new(LengthFeature {}) as Box<_>,
                 },
             ],
         };
@@ -164,27 +176,25 @@ mod tests {
 
         // Then
         let expected_features = vec![
-            vec![
-                ("length[+1]".to_string(), "6".to_string())
-            ],
+            vec![("length[+1]".to_string(), "6".to_string())],
             vec![
                 ("is_digit[+3]".to_string(), "1".to_string()),
                 ("length[-1]".to_string(), "1".to_string()),
-                ("length[+1]".to_string(), "1".to_string())
+                ("length[+1]".to_string(), "1".to_string()),
             ],
             vec![
                 ("is_digit".to_string(), "1".to_string()),
                 ("length[-1]".to_string(), "6".to_string()),
-                ("length[+1]".to_string(), "4".to_string())
+                ("length[+1]".to_string(), "4".to_string()),
             ],
             vec![
                 ("length[-1]".to_string(), "1".to_string()),
-                ("length[+1]".to_string(), "3".to_string())
+                ("length[+1]".to_string(), "3".to_string()),
             ],
             vec![
                 ("is_digit[-2]".to_string(), "1".to_string()),
                 ("is_digit".to_string(), "1".to_string()),
-                ("length[-1]".to_string(), "4".to_string())
+                ("length[-1]".to_string(), "4".to_string()),
             ],
         ];
         assert_eq!(expected_features, computed_features);

--- a/snips-nlu-lib/src/slot_filler/feature_processor.rs
+++ b/snips-nlu-lib/src/slot_filler/feature_processor.rs
@@ -1,12 +1,13 @@
-use itertools::Itertools;
 use std::collections::HashMap;
-
-use models::FeatureFactory;
-use errors::*;
-use nlu_utils::token::Token;
-use resources::SharedResources;
 use std::sync::Arc;
-use slot_filler::features::*;
+
+use itertools::Itertools;
+use nlu_utils::token::Token;
+
+use crate::errors::*;
+use crate::models::FeatureFactory;
+use crate::resources::SharedResources;
+use crate::slot_filler::features::*;
 
 pub struct ProbabilisticFeatureProcessor {
     features_offsetters: Vec<FeatureOffsetter>,
@@ -80,7 +81,7 @@ pub trait FeatureKindRepr {
 pub trait Feature: FeatureKindRepr + Send + Sync {
     fn name(&self) -> String { self.feature_kind().identifier().to_string() }
     fn build_features(
-        args: &HashMap<String, ::serde_json::Value>,
+        args: &HashMap<String, serde_json::Value>,
         shared_resources: Arc<SharedResources>,
     ) -> Result<Vec<Box<Feature>>> where Self: Sized;
     fn compute(&self, tokens: &[Token], token_index: usize) -> Result<Option<String>>;

--- a/snips-nlu-lib/src/slot_filler/features.rs
+++ b/snips-nlu-lib/src/slot_filler/features.rs
@@ -117,7 +117,7 @@ impl Feature for NgramFeature {
                 shared_resources
                     .gazetteers
                     .get(&gazetteer_name)
-                    .map(|gazetteer| gazetteer.clone())
+                    .cloned()
                     .ok_or_else(|| {
                         format_err!(
                             "Cannot find gazetteer '{}' in shared resources",
@@ -393,7 +393,7 @@ impl Feature for WordClusterFeature {
         let word_clusterer = shared_resources
             .word_clusterers
             .get(&cluster_name)
-            .map(|clusterer| clusterer.clone())
+            .cloned()
             .ok_or_else(|| {
                 format_err!(
                     "Cannot find word clusters '{}' in shared resources",

--- a/snips-nlu-lib/src/slot_filler/features.rs
+++ b/snips-nlu-lib/src/slot_filler/features.rs
@@ -7,15 +7,15 @@ use nlu_utils::string::{get_shape, normalize};
 use nlu_utils::token::Token;
 use snips_nlu_ontology::BuiltinEntityKind;
 
-use crate::entity_parser::{CustomEntityParser, BuiltinEntityParser};
+use crate::entity_parser::{BuiltinEntityParser, CustomEntityParser};
 use crate::errors::*;
 use crate::resources::gazetteer::Gazetteer;
-use crate::resources::SharedResources;
 use crate::resources::stemmer::Stemmer;
 use crate::resources::word_clusterer::WordClusterer;
+use crate::resources::SharedResources;
 
-use super::feature_processor::{Feature, FeatureKindRepr};
 use super::crf_utils::{get_scheme_prefix, TaggingScheme};
+use super::feature_processor::{Feature, FeatureKindRepr};
 use super::features_utils::{get_word_chunk, initial_string_from_tokens};
 
 pub struct IsDigitFeature {}
@@ -29,11 +29,13 @@ impl Feature for IsDigitFeature {
     }
 
     fn compute(&self, tokens: &[Token], token_index: usize) -> Result<Option<String>> {
-        Ok(if tokens[token_index].value.chars().all(|c| c.is_digit(10)) {
-            Some("1".to_string())
-        } else {
-            None
-        })
+        Ok(
+            if tokens[token_index].value.chars().all(|c| c.is_digit(10)) {
+                Some("1".to_string())
+            } else {
+                None
+            },
+        )
     }
 }
 
@@ -48,7 +50,10 @@ impl Feature for LengthFeature {
     }
 
     fn compute(&self, tokens: &[Token], token_index: usize) -> Result<Option<String>> {
-        Ok(Some(format!("{:?}", &tokens[token_index].value.chars().count())))
+        Ok(Some(format!(
+            "{:?}",
+            &tokens[token_index].value.chars().count()
+        )))
     }
 }
 
@@ -108,28 +113,37 @@ impl Feature for NgramFeature {
         let n = parse_as_u64(args, "n")? as usize;
         let common_words_gazetteer_name = parse_as_opt_string(args, "common_words_gazetteer_name")?;
         let opt_common_words_gazetteer = if let Some(gazetteer_name) = common_words_gazetteer_name {
-            Some(shared_resources.gazetteers.get(&gazetteer_name)
-                .map(|gazetteer| gazetteer.clone())
-                .ok_or_else(||
-                    format_err!("Cannot find gazetteer '{}' in shared resources", gazetteer_name))?)
+            Some(
+                shared_resources
+                    .gazetteers
+                    .get(&gazetteer_name)
+                    .map(|gazetteer| gazetteer.clone())
+                    .ok_or_else(|| {
+                        format_err!(
+                            "Cannot find gazetteer '{}' in shared resources",
+                            gazetteer_name
+                        )
+                    })?,
+            )
         } else {
             None
         };
         let use_stemming = parse_as_bool(args, "use_stemming")?;
         let opt_stemmer = if use_stemming {
-            Some(shared_resources.stemmer
-                .clone()
-                .ok_or_else(|| format_err!("Cannot find stemmer in shared resources"))?)
+            Some(
+                shared_resources
+                    .stemmer
+                    .clone()
+                    .ok_or_else(|| format_err!("Cannot find stemmer in shared resources"))?,
+            )
         } else {
             None
         };
-        Ok(vec![Box::new(
-            Self {
-                ngram_size: n,
-                opt_common_words_gazetteer,
-                opt_stemmer,
-            }
-        )])
+        Ok(vec![Box::new(Self {
+            ngram_size: n,
+            opt_common_words_gazetteer,
+            opt_stemmer,
+        })])
     }
 
     fn compute(&self, tokens: &[Token], token_index: usize) -> Result<Option<String>> {
@@ -140,7 +154,8 @@ impl Feature for NgramFeature {
         let result = tokens[token_index..token_index + self.ngram_size]
             .iter()
             .map(|token| {
-                let stemmed_value = self.opt_stemmer
+                let stemmed_value = self
+                    .opt_stemmer
                     .as_ref()
                     .map(|stemmer| stemmer.stem(&normalize(&token.value)))
                     .unwrap_or_else(|| normalize(&token.value));
@@ -236,7 +251,12 @@ impl Feature for SuffixFeature {
     fn compute(&self, tokens: &[Token], token_index: usize) -> Result<Option<String>> {
         let normalized = normalize(&tokens[token_index].value);
         let chunk_start = normalized.chars().count();
-        Ok(get_word_chunk(&normalized, self.suffix_size, chunk_start, true))
+        Ok(get_word_chunk(
+            &normalized,
+            self.suffix_size,
+            chunk_start,
+            true,
+        ))
     }
 }
 
@@ -261,9 +281,12 @@ impl Feature for CustomEntityMatchFeature {
         let tagging_scheme = TaggingScheme::from_u8(tagging_scheme_code)?;
         let use_stemming = parse_as_bool(args, "use_stemming")?;
         let opt_stemmer = if use_stemming {
-            Some(shared_resources.stemmer
-                .clone()
-                .ok_or_else(|| format_err!("Cannot find stemmer in shared resources"))?)
+            Some(
+                shared_resources
+                    .stemmer
+                    .clone()
+                    .ok_or_else(|| format_err!("Cannot find stemmer in shared resources"))?,
+            )
         } else {
             None
         };
@@ -284,7 +307,8 @@ impl Feature for CustomEntityMatchFeature {
         let normalized_tokens = transform_tokens(tokens, self.opt_stemmer.clone());
         let normalized_text = initial_string_from_tokens(&*normalized_tokens);
 
-        Ok(self.custom_entity_parser
+        Ok(self
+            .custom_entity_parser
             .extract_entities(&normalized_text, Some(&[self.entity_name.clone()]))?
             .into_iter()
             .find(|e| ranges_overlap(&e.range, &normalized_tokens[token_index].char_range))
@@ -292,7 +316,8 @@ impl Feature for CustomEntityMatchFeature {
                 let entity_token_indexes = (0..normalized_tokens.len())
                     .filter(|i| ranges_overlap(&normalized_tokens[*i].char_range, &e.range))
                     .collect_vec();
-                get_scheme_prefix(token_index, &entity_token_indexes, self.tagging_scheme).to_string()
+                get_scheme_prefix(token_index, &entity_token_indexes, self.tagging_scheme)
+                    .to_string()
             }))
     }
 }
@@ -305,7 +330,11 @@ pub struct BuiltinEntityMatchFeature {
 
 impl Feature for BuiltinEntityMatchFeature {
     fn name(&self) -> String {
-        format!("{}_{}", self.feature_kind().identifier(), self.builtin_entity_kind.identifier())
+        format!(
+            "{}_{}",
+            self.feature_kind().identifier(),
+            self.builtin_entity_kind.identifier()
+        )
     }
 
     fn build_features(
@@ -331,7 +360,8 @@ impl Feature for BuiltinEntityMatchFeature {
 
     fn compute(&self, tokens: &[Token], token_index: usize) -> Result<Option<String>> {
         let text = initial_string_from_tokens(tokens);
-        Ok(self.builtin_entity_parser
+        Ok(self
+            .builtin_entity_parser
             .extract_entities(&text, Some(&[self.builtin_entity_kind]), true)?
             .into_iter()
             .find(|e| ranges_overlap(&e.range, &tokens[token_index].char_range))
@@ -339,7 +369,8 @@ impl Feature for BuiltinEntityMatchFeature {
                 let entity_token_indexes = (0..tokens.len())
                     .filter(|i| ranges_overlap(&tokens[*i].char_range, &e.range))
                     .collect_vec();
-                get_scheme_prefix(token_index, &entity_token_indexes, self.tagging_scheme).to_string()
+                get_scheme_prefix(token_index, &entity_token_indexes, self.tagging_scheme)
+                    .to_string()
             }))
     }
 }
@@ -359,11 +390,16 @@ impl Feature for WordClusterFeature {
         shared_resources: Arc<SharedResources>,
     ) -> Result<Vec<Box<Feature>>> {
         let cluster_name = parse_as_string(args, "cluster_name")?;
-        let word_clusterer = shared_resources.word_clusterers
+        let word_clusterer = shared_resources
+            .word_clusterers
             .get(&cluster_name)
             .map(|clusterer| clusterer.clone())
-            .ok_or_else(|| format_err!(
-                "Cannot find word clusters '{}' in shared resources", cluster_name))?;
+            .ok_or_else(|| {
+                format_err!(
+                    "Cannot find word clusters '{}' in shared resources",
+                    cluster_name
+                )
+            })?;
         Ok(vec![Box::new(Self {
             cluster_name,
             word_clusterer,
@@ -371,7 +407,9 @@ impl Feature for WordClusterFeature {
     }
 
     fn compute(&self, tokens: &[Token], token_index: usize) -> Result<Option<String>> {
-        Ok(self.word_clusterer.get_cluster(&tokens[token_index].value.to_lowercase()))
+        Ok(self
+            .word_clusterer
+            .get_cluster(&tokens[token_index].value.to_lowercase()))
     }
 }
 
@@ -384,7 +422,8 @@ fn transform_tokens(tokens: &[Token], stemmer: Option<Arc<Stemmer>>) -> Vec<Toke
             let normalized_value = stemmer
                 .clone()
                 .map_or(normalize(&t.value), |s| s.stem(&normalize(&t.value)));
-            let char_range = current_char_index..(current_char_index + normalized_value.chars().count());
+            let char_range =
+                current_char_index..(current_char_index + normalized_value.chars().count());
             let byte_range = current_byte_index..(current_byte_index + normalized_value.len());
             current_char_index = char_range.end + 1;
             current_byte_index = byte_range.end + 1;
@@ -394,7 +433,8 @@ fn transform_tokens(tokens: &[Token], stemmer: Option<Arc<Stemmer>>) -> Vec<Toke
 }
 
 fn parse_as_string(args: &HashMap<String, serde_json::Value>, arg_name: &str) -> Result<String> {
-    Ok(args.get(arg_name)
+    Ok(args
+        .get(arg_name)
         .ok_or_else(|| format_err!("can't retrieve '{}' parameter", arg_name))?
         .as_str()
         .ok_or_else(|| format_err!("'{}' isn't a string", arg_name))?
@@ -405,7 +445,8 @@ fn parse_as_opt_string(
     args: &HashMap<String, serde_json::Value>,
     arg_name: &str,
 ) -> Result<Option<String>> {
-    Ok(args.get(arg_name)
+    Ok(args
+        .get(arg_name)
         .ok_or_else(|| format_err!("can't retrieve '{}' parameter", arg_name))?
         .as_str()
         .map(|s| s.to_string()))
@@ -429,14 +470,16 @@ fn parse_as_vec_string(
 }
 
 fn parse_as_bool(args: &HashMap<String, serde_json::Value>, arg_name: &str) -> Result<bool> {
-    Ok(args.get(arg_name)
+    Ok(args
+        .get(arg_name)
         .ok_or_else(|| format_err!("can't retrieve '{}' parameter", arg_name))?
         .as_bool()
         .ok_or_else(|| format_err!("'{}' isn't a bool", arg_name))?)
 }
 
 fn parse_as_u64(args: &HashMap<String, serde_json::Value>, arg_name: &str) -> Result<u64> {
-    Ok(args.get(arg_name)
+    Ok(args
+        .get(arg_name)
         .ok_or_else(|| format_err!("can't retrieve '{}' parameter", arg_name))?
         .as_u64()
         .ok_or_else(|| format_err!("'{}' isn't a u64", arg_name))?)
@@ -446,58 +489,36 @@ fn parse_as_u64(args: &HashMap<String, serde_json::Value>, arg_name: &str) -> Re
 mod tests {
     use std::iter::FromIterator;
 
-    use snips_nlu_ontology::{BuiltinEntity, SlotValue, TemperatureValue};
     use nlu_utils::language::Language as NluUtilsLanguage;
     use nlu_utils::token::tokenize;
+    use snips_nlu_ontology::{BuiltinEntity, SlotValue, TemperatureValue};
 
+    use super::*;
     use crate::entity_parser::custom_entity_parser::CustomEntity;
     use crate::resources::gazetteer::HashSetGazetteer;
     use crate::resources::stemmer::HashMapStemmer;
     use crate::resources::word_clusterer::HashMapWordClusterer;
     use crate::testutils::{MockedBuiltinEntityParser, MockedCustomEntityParser};
-    use super::*;
 
     #[test]
     fn transform_tokens_should_work() {
         // Given
         let tokens = tokenize("fo£ root_suffix inflection bar", NluUtilsLanguage::EN);
-        let stemmer = HashMapStemmer::from_iter(
-            vec![
-                ("root_suffix".to_string(), "root".to_string()),
-                ("inflection".to_string(), "original_word".to_string())
-            ]
-        );
+        let stemmer = HashMapStemmer::from_iter(vec![
+            ("root_suffix".to_string(), "root".to_string()),
+            ("inflection".to_string(), "original_word".to_string()),
+        ]);
 
         // When
         let transformed_tokens = transform_tokens(&tokens, Some(Arc::new(stemmer)));
 
         // Then
         let expected_tokens = vec![
-            Token::new(
-                "fo".to_string(),
-                0..2,
-                0..2,
-            ),
-            Token::new(
-                "£".to_string(),
-                3..5,
-                3..4,
-            ),
-            Token::new(
-                "root".to_string(),
-                6..10,
-                5..9,
-            ),
-            Token::new(
-                "original_word".to_string(),
-                11..24,
-                10..23,
-            ),
-            Token::new(
-                "bar".to_string(),
-                25..28,
-                24..27,
-            )
+            Token::new("fo".to_string(), 0..2, 0..2),
+            Token::new("£".to_string(), 3..5, 3..4),
+            Token::new("root".to_string(), 6..10, 5..9),
+            Token::new("original_word".to_string(), 11..24, 10..23),
+            Token::new("bar".to_string(), 25..28, 24..27),
         ];
         assert_eq!(expected_tokens, transformed_tokens);
     }
@@ -588,7 +609,7 @@ mod tests {
             Some("Xxx XXX".to_string()),
             Some("XXX xxx".to_string()),
             Some("xxx xX".to_string()),
-            None
+            None,
         ];
         assert_eq!(expected_result, results);
     }
@@ -614,7 +635,7 @@ mod tests {
             Some("i love".to_string()),
             Some("love house".to_string()),
             Some("house music".to_string()),
-            None
+            None,
         ];
 
         assert_eq!(expected_results, results);
@@ -644,7 +665,7 @@ mod tests {
             Some("i love".to_string()),
             Some("love rare_word".to_string()),
             Some("rare_word music".to_string()),
-            None
+            None,
         ];
         assert_eq!(expected_results, results);
     }
@@ -654,9 +675,8 @@ mod tests {
         // Given
         let language = NluUtilsLanguage::EN;
         let tokens = tokenize("I love House Music", language);
-        let stemmer = HashMapStemmer::from_iter(
-            vec![("house".to_string(), "hous".to_string())].into_iter()
-        );
+        let stemmer =
+            HashMapStemmer::from_iter(vec![("house".to_string(), "hous".to_string())].into_iter());
         let feature = NgramFeature {
             ngram_size: 2,
             opt_common_words_gazetteer: None,
@@ -684,19 +704,15 @@ mod tests {
         // Given
         let language = NluUtilsLanguage::EN;
         let entity_name = "bird_type".to_string();
-        let mocked_entity_parser = MockedCustomEntityParser::from_iter(
-            vec![(
-                "i love this beautiful blue bird !".to_string(),
-                vec![
-                    CustomEntity {
-                        value: "beautiful blue bird".to_string(),
-                        resolved_value: "beautiful blue bird".to_string(),
-                        range: 12..31,
-                        entity_identifier: entity_name.to_string(),
-                    }
-                ]
-            )]
-        );
+        let mocked_entity_parser = MockedCustomEntityParser::from_iter(vec![(
+            "i love this beautiful blue bird !".to_string(),
+            vec![CustomEntity {
+                value: "beautiful blue bird".to_string(),
+                resolved_value: "beautiful blue bird".to_string(),
+                range: 12..31,
+                entity_identifier: entity_name.to_string(),
+            }],
+        )]);
         let tagging_scheme = TaggingScheme::BILOU;
         let tokens = tokenize("I love this beautiful blue Bird !", language);
         let feature = CustomEntityMatchFeature {
@@ -729,19 +745,15 @@ mod tests {
         let language = NluUtilsLanguage::EN;
         let stemmer = HashMapStemmer::from_iter(vec![("birds".to_string(), "bird".to_string())]);
 
-        let mocked_entity_parser = MockedCustomEntityParser::from_iter(
-            vec![(
-                "i love blue bird !".to_string(),
-                vec![
-                    CustomEntity {
-                        value: "blue bird".to_string(),
-                        resolved_value: "blue bird".to_string(),
-                        range: 7..16,
-                        entity_identifier: "bird_type".to_string(),
-                    }
-                ]
-            )]
-        );
+        let mocked_entity_parser = MockedCustomEntityParser::from_iter(vec![(
+            "i love blue bird !".to_string(),
+            vec![CustomEntity {
+                value: "blue bird".to_string(),
+                resolved_value: "blue bird".to_string(),
+                range: 7..16,
+                entity_identifier: "bird_type".to_string(),
+            }],
+        )]);
 
         let tagging_scheme = TaggingScheme::BILOU;
         let tokens = tokenize("I love Blue Birds !", language);
@@ -763,7 +775,7 @@ mod tests {
             None,
             Some("B-".to_string()),
             Some("L-".to_string()),
-            None
+            None,
         ];
         assert_eq!(expected_results, results);
     }
@@ -775,19 +787,18 @@ mod tests {
         let input = "Please raise to twenty one degrees ok ?";
         let tokens = tokenize(input, language);
         let tagging_scheme = TaggingScheme::BILOU;
-        let mocked_builtin_parser = MockedBuiltinEntityParser::from_iter(
-            vec![(
-                input.to_string(),
-                vec![
-                    BuiltinEntity {
-                        value: "twenty one degrees".to_string(),
-                        range: 16..34,
-                        entity: SlotValue::Temperature(TemperatureValue { value: 21.0, unit: None }),
-                        entity_kind: BuiltinEntityKind::Temperature,
-                    }
-                ]
-            )]
-        );
+        let mocked_builtin_parser = MockedBuiltinEntityParser::from_iter(vec![(
+            input.to_string(),
+            vec![BuiltinEntity {
+                value: "twenty one degrees".to_string(),
+                range: 16..34,
+                entity: SlotValue::Temperature(TemperatureValue {
+                    value: 21.0,
+                    unit: None,
+                }),
+                entity_kind: BuiltinEntityKind::Temperature,
+            }],
+        )]);
 
         let feature = BuiltinEntityMatchFeature {
             tagging_scheme,
@@ -808,7 +819,7 @@ mod tests {
             Some("B-".to_string()),
             Some("I-".to_string()),
             Some("L-".to_string()),
-            None
+            None,
         ];
         assert_eq!(expected_results, results);
     }
@@ -818,7 +829,7 @@ mod tests {
         // Given
         let language = NluUtilsLanguage::EN;
         let word_clusterer = HashMapWordClusterer::from_iter(
-            vec![("bird".to_string(), "010101".to_string())].into_iter()
+            vec![("bird".to_string(), "010101".to_string())].into_iter(),
         );
         let tokens = tokenize("I love this bird", language);
         let feature = WordClusterFeature {
@@ -832,12 +843,7 @@ mod tests {
             .collect();
 
         // Then
-        let expected_results = vec![
-            None,
-            None,
-            None,
-            Some("010101".to_string())
-        ];
+        let expected_results = vec![None, None, None, Some("010101".to_string())];
         assert_eq!(expected_results, results);
     }
 }

--- a/snips-nlu-lib/src/slot_filler/features.rs
+++ b/snips-nlu-lib/src/slot_filler/features.rs
@@ -1,18 +1,20 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use entity_parser::{CustomEntityParser, BuiltinEntityParser};
-use errors::*;
 use itertools::Itertools;
 use nlu_utils::range::ranges_overlap;
 use nlu_utils::string::{get_shape, normalize};
 use nlu_utils::token::Token;
-use resources::gazetteer::Gazetteer;
-use resources::SharedResources;
-use resources::stemmer::Stemmer;
-use resources::word_clusterer::WordClusterer;
-use slot_filler::feature_processor::{Feature, FeatureKindRepr};
 use snips_nlu_ontology::BuiltinEntityKind;
+
+use crate::entity_parser::{CustomEntityParser, BuiltinEntityParser};
+use crate::errors::*;
+use crate::resources::gazetteer::Gazetteer;
+use crate::resources::SharedResources;
+use crate::resources::stemmer::Stemmer;
+use crate::resources::word_clusterer::WordClusterer;
+
+use super::feature_processor::{Feature, FeatureKindRepr};
 use super::crf_utils::{get_scheme_prefix, TaggingScheme};
 use super::features_utils::{get_word_chunk, initial_string_from_tokens};
 
@@ -20,7 +22,7 @@ pub struct IsDigitFeature {}
 
 impl Feature for IsDigitFeature {
     fn build_features(
-        _args: &HashMap<String, ::serde_json::Value>,
+        _args: &HashMap<String, serde_json::Value>,
         _shared_resources: Arc<SharedResources>,
     ) -> Result<Vec<Box<Feature>>> {
         Ok(vec![Box::new(Self {})])
@@ -39,7 +41,7 @@ pub struct LengthFeature {}
 
 impl Feature for LengthFeature {
     fn build_features(
-        _args: &HashMap<String, ::serde_json::Value>,
+        _args: &HashMap<String, serde_json::Value>,
         _shared_resources: Arc<SharedResources>,
     ) -> Result<Vec<Box<Feature>>> {
         Ok(vec![Box::new(Self {})])
@@ -54,7 +56,7 @@ pub struct IsFirstFeature {}
 
 impl Feature for IsFirstFeature {
     fn build_features(
-        _args: &HashMap<String, ::serde_json::Value>,
+        _args: &HashMap<String, serde_json::Value>,
         _shared_resources: Arc<SharedResources>,
     ) -> Result<Vec<Box<Feature>>> {
         Ok(vec![Box::new(Self {})])
@@ -73,7 +75,7 @@ pub struct IsLastFeature {}
 
 impl Feature for IsLastFeature {
     fn build_features(
-        _args: &HashMap<String, ::serde_json::Value>,
+        _args: &HashMap<String, serde_json::Value>,
         _shared_resources: Arc<SharedResources>,
     ) -> Result<Vec<Box<Feature>>> {
         Ok(vec![Box::new(Self {})])
@@ -100,7 +102,7 @@ impl Feature for NgramFeature {
     }
 
     fn build_features(
-        args: &HashMap<String, ::serde_json::Value>,
+        args: &HashMap<String, serde_json::Value>,
         shared_resources: Arc<SharedResources>,
     ) -> Result<Vec<Box<Feature>>> {
         let n = parse_as_u64(args, "n")? as usize;
@@ -168,7 +170,7 @@ impl Feature for ShapeNgramFeature {
     }
 
     fn build_features(
-        args: &HashMap<String, ::serde_json::Value>,
+        args: &HashMap<String, serde_json::Value>,
         _shared_resources: Arc<SharedResources>,
     ) -> Result<Vec<Box<Feature>>> {
         let ngram_size = parse_as_u64(args, "n")? as usize;
@@ -201,7 +203,7 @@ impl Feature for PrefixFeature {
     }
 
     fn build_features(
-        args: &HashMap<String, ::serde_json::Value>,
+        args: &HashMap<String, serde_json::Value>,
         _shared_resources: Arc<SharedResources>,
     ) -> Result<Vec<Box<Feature>>> {
         let prefix_size = parse_as_u64(args, "prefix_size")? as usize;
@@ -224,7 +226,7 @@ impl Feature for SuffixFeature {
     }
 
     fn build_features(
-        args: &HashMap<String, ::serde_json::Value>,
+        args: &HashMap<String, serde_json::Value>,
         _shared_resources: Arc<SharedResources>,
     ) -> Result<Vec<Box<Feature>>> {
         let suffix_size = parse_as_u64(args, "suffix_size")? as usize;
@@ -251,7 +253,7 @@ impl Feature for CustomEntityMatchFeature {
     }
 
     fn build_features(
-        args: &HashMap<String, ::serde_json::Value>,
+        args: &HashMap<String, serde_json::Value>,
         shared_resources: Arc<SharedResources>,
     ) -> Result<Vec<Box<Feature>>> {
         let entities = parse_as_vec_string(args, "entities")?;
@@ -307,7 +309,7 @@ impl Feature for BuiltinEntityMatchFeature {
     }
 
     fn build_features(
-        args: &HashMap<String, ::serde_json::Value>,
+        args: &HashMap<String, serde_json::Value>,
         shared_resources: Arc<SharedResources>,
     ) -> Result<Vec<Box<Feature>>> {
         let builtin_entity_labels = parse_as_vec_string(args, "entity_labels")?;
@@ -353,7 +355,7 @@ impl Feature for WordClusterFeature {
     }
 
     fn build_features(
-        args: &HashMap<String, ::serde_json::Value>,
+        args: &HashMap<String, serde_json::Value>,
         shared_resources: Arc<SharedResources>,
     ) -> Result<Vec<Box<Feature>>> {
         let cluster_name = parse_as_string(args, "cluster_name")?;
@@ -391,7 +393,7 @@ fn transform_tokens(tokens: &[Token], stemmer: Option<Arc<Stemmer>>) -> Vec<Toke
         .collect_vec()
 }
 
-fn parse_as_string(args: &HashMap<String, ::serde_json::Value>, arg_name: &str) -> Result<String> {
+fn parse_as_string(args: &HashMap<String, serde_json::Value>, arg_name: &str) -> Result<String> {
     Ok(args.get(arg_name)
         .ok_or_else(|| format_err!("can't retrieve '{}' parameter", arg_name))?
         .as_str()
@@ -400,7 +402,7 @@ fn parse_as_string(args: &HashMap<String, ::serde_json::Value>, arg_name: &str) 
 }
 
 fn parse_as_opt_string(
-    args: &HashMap<String, ::serde_json::Value>,
+    args: &HashMap<String, serde_json::Value>,
     arg_name: &str,
 ) -> Result<Option<String>> {
     Ok(args.get(arg_name)
@@ -410,7 +412,7 @@ fn parse_as_opt_string(
 }
 
 fn parse_as_vec_string(
-    args: &HashMap<String, ::serde_json::Value>,
+    args: &HashMap<String, serde_json::Value>,
     arg_name: &str,
 ) -> Result<Vec<String>> {
     args.get(arg_name)
@@ -426,14 +428,14 @@ fn parse_as_vec_string(
         .collect()
 }
 
-fn parse_as_bool(args: &HashMap<String, ::serde_json::Value>, arg_name: &str) -> Result<bool> {
+fn parse_as_bool(args: &HashMap<String, serde_json::Value>, arg_name: &str) -> Result<bool> {
     Ok(args.get(arg_name)
         .ok_or_else(|| format_err!("can't retrieve '{}' parameter", arg_name))?
         .as_bool()
         .ok_or_else(|| format_err!("'{}' isn't a bool", arg_name))?)
 }
 
-fn parse_as_u64(args: &HashMap<String, ::serde_json::Value>, arg_name: &str) -> Result<u64> {
+fn parse_as_u64(args: &HashMap<String, serde_json::Value>, arg_name: &str) -> Result<u64> {
     Ok(args.get(arg_name)
         .ok_or_else(|| format_err!("can't retrieve '{}' parameter", arg_name))?
         .as_u64()
@@ -443,15 +445,17 @@ fn parse_as_u64(args: &HashMap<String, ::serde_json::Value>, arg_name: &str) -> 
 #[cfg(test)]
 mod tests {
     use std::iter::FromIterator;
+
+    use snips_nlu_ontology::{BuiltinEntity, SlotValue, TemperatureValue};
     use nlu_utils::language::Language as NluUtilsLanguage;
     use nlu_utils::token::tokenize;
-    use resources::gazetteer::HashSetGazetteer;
-    use resources::stemmer::HashMapStemmer;
-    use resources::word_clusterer::HashMapWordClusterer;
-    use snips_nlu_ontology::{BuiltinEntity, SlotValue, TemperatureValue};
+
+    use crate::entity_parser::custom_entity_parser::CustomEntity;
+    use crate::resources::gazetteer::HashSetGazetteer;
+    use crate::resources::stemmer::HashMapStemmer;
+    use crate::resources::word_clusterer::HashMapWordClusterer;
+    use crate::testutils::{MockedBuiltinEntityParser, MockedCustomEntityParser};
     use super::*;
-    use testutils::{MockedBuiltinEntityParser, MockedCustomEntityParser};
-    use entity_parser::custom_entity_parser::CustomEntity;
 
     #[test]
     fn transform_tokens_should_work() {

--- a/snips-nlu-lib/src/slot_filler/macros.rs
+++ b/snips-nlu-lib/src/slot_filler/macros.rs
@@ -10,7 +10,7 @@ macro_rules! get_features {
             pub fn identifier(&self) -> &'static str {
                 match self {
                     $(
-                        &FeatureKind::$feature_type => stringify!($feature_name),
+                        FeatureKind::$feature_type => stringify!($feature_name),
                     )*
                 }
             }

--- a/snips-nlu-lib/src/slot_filler/mod.rs
+++ b/snips-nlu-lib/src/slot_filler/mod.rs
@@ -29,17 +29,21 @@ pub trait SlotFiller: Send + Sync {
 
 pub fn build_slot_filler<P: AsRef<Path>>(
     path: P,
-    shared_resources: Arc<SharedResources>
+    shared_resources: Arc<SharedResources>,
 ) -> Result<Box<SlotFiller>> {
     let metadata_path = path.as_ref().join("metadata.json");
-    let metadata_file = File::open(&metadata_path)
-        .with_context(|_| format!("Cannot open slot filler metadata file '{:?}'",
-                                  &metadata_path))?;
+    let metadata_file = File::open(&metadata_path).with_context(|_| {
+        format!(
+            "Cannot open slot filler metadata file '{:?}'",
+            &metadata_path
+        )
+    })?;
     let metadata: ProcessingUnitMetadata = serde_json::from_reader(metadata_file)
         .with_context(|_| "Cannot deserialize slot filler json data")?;
     match metadata {
-        ProcessingUnitMetadata::CrfSlotFiller =>
-            Ok(Box::new(CRFSlotFiller::from_path(path, shared_resources)?) as _),
-        _ => Err(format_err!("{:?} is not a slot filler", metadata))
+        ProcessingUnitMetadata::CrfSlotFiller => {
+            Ok(Box::new(CRFSlotFiller::from_path(path, shared_resources)?) as _)
+        }
+        _ => Err(format_err!("{:?} is not a slot filler", metadata)),
     }
 }

--- a/snips-nlu-lib/src/slot_filler/mod.rs
+++ b/snips-nlu-lib/src/slot_filler/mod.rs
@@ -10,16 +10,16 @@ use std::fs::File;
 use std::path::Path;
 use std::sync::Arc;
 
-use errors::*;
 use failure::ResultExt;
-use serde_json;
+use nlu_utils::token::Token;
+
+use crate::errors::*;
+use crate::models::ProcessingUnitMetadata;
+use crate::resources::SharedResources;
+use crate::slot_utils::InternalSlot;
 
 pub use self::crf_slot_filler::*;
 use self::crf_utils::TaggingScheme;
-use models::ProcessingUnitMetadata;
-use nlu_utils::token::Token;
-use resources::SharedResources;
-use slot_utils::InternalSlot;
 
 pub trait SlotFiller: Send + Sync {
     fn get_tagging_scheme(&self) -> TaggingScheme;

--- a/snips-nlu-lib/src/slot_utils.rs
+++ b/snips-nlu-lib/src/slot_utils.rs
@@ -1,11 +1,12 @@
 use std::ops::Range;
 use std::sync::Arc;
 
-use entity_parser::{CustomEntityParser, CustomEntity, BuiltinEntityParser};
-use errors::*;
-use models::nlu_engine::Entity;
 use snips_nlu_ontology::{BuiltinEntity, BuiltinEntityKind, Slot, SlotValue};
-use utils::{EntityName, SlotName};
+
+use crate::errors::*;
+use crate::entity_parser::{CustomEntityParser, CustomEntity, BuiltinEntityParser};
+use crate::models::nlu_engine::Entity;
+use crate::utils::{EntityName, SlotName};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct InternalSlot {
@@ -97,11 +98,14 @@ fn convert_to_builtin_slot(slot: InternalSlot, slot_value: SlotValue) -> Slot {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::iter::FromIterator;
+
     use snips_nlu_ontology::*;
-    use models::nlu_engine::Entity;
-    use testutils::*;
+
+    use crate::models::nlu_engine::Entity;
+    use crate::testutils::*;
+
+    use super::*;
 
     #[test]
     fn should_resolve_builtin_slot() {

--- a/snips-nlu-lib/src/slot_utils.rs
+++ b/snips-nlu-lib/src/slot_utils.rs
@@ -18,7 +18,7 @@ pub struct InternalSlot {
 
 pub fn resolve_builtin_slot(
     internal_slot: InternalSlot,
-    builtin_entities: &Vec<BuiltinEntity>,
+    builtin_entities: &[BuiltinEntity],
     builtin_entity_parser: Arc<BuiltinEntityParser>,
 ) -> Result<Option<Slot>> {
     let entity_kind = BuiltinEntityKind::from_identifier(&internal_slot.entity)?;
@@ -37,10 +37,10 @@ pub fn resolve_builtin_slot(
 pub fn resolve_custom_slot(
     internal_slot: InternalSlot,
     entity: &Entity,
-    custom_entities: &Vec<CustomEntity>,
+    custom_entities: &[CustomEntity],
     custom_entity_parser: Arc<CustomEntityParser>,
 ) -> Result<Option<Slot>> {
-    let opt_matching_entity = match custom_entities.into_iter().find(|custom_entity| {
+    let opt_matching_entity = match custom_entities.iter().find(|custom_entity| {
         custom_entity.entity_identifier == internal_slot.entity
             && custom_entity.range == internal_slot.char_range
     }) {

--- a/snips-nlu-lib/src/testutils.rs
+++ b/snips-nlu-lib/src/testutils.rs
@@ -5,15 +5,15 @@ use std::sync::Arc;
 use ndarray::prelude::*;
 use snips_nlu_ontology::{BuiltinEntity, BuiltinEntityKind};
 
-use entity_parser::{BuiltinEntityParser, CustomEntity, CustomEntityParser};
-use errors::*;
-use resources::SharedResources;
-use resources::gazetteer::Gazetteer;
-use resources::stemmer::Stemmer;
-use resources::word_clusterer::WordClusterer;
+use crate::entity_parser::{BuiltinEntityParser, CustomEntity, CustomEntityParser};
+use crate::errors::*;
+use crate::resources::SharedResources;
+use crate::resources::gazetteer::Gazetteer;
+use crate::resources::stemmer::Stemmer;
+use crate::resources::word_clusterer::WordClusterer;
 
-pub fn file_path(filename: &str) -> ::std::path::PathBuf {
-    ::dinghy_test::try_test_file_path("data")
+pub fn file_path(filename: &str) ->::std::path::PathBuf {
+    dinghy_test::try_test_file_path("data")
         .unwrap_or_else(|| "../data".into())
         .join(filename)
 }

--- a/snips-nlu-lib/src/testutils.rs
+++ b/snips-nlu-lib/src/testutils.rs
@@ -7,12 +7,12 @@ use snips_nlu_ontology::{BuiltinEntity, BuiltinEntityKind};
 
 use crate::entity_parser::{BuiltinEntityParser, CustomEntity, CustomEntityParser};
 use crate::errors::*;
-use crate::resources::SharedResources;
 use crate::resources::gazetteer::Gazetteer;
 use crate::resources::stemmer::Stemmer;
 use crate::resources::word_clusterer::WordClusterer;
+use crate::resources::SharedResources;
 
-pub fn file_path(filename: &str) ->::std::path::PathBuf {
+pub fn file_path(filename: &str) -> ::std::path::PathBuf {
     dinghy_test::try_test_file_path("data")
         .unwrap_or_else(|| "../data".into())
         .join(filename)
@@ -30,14 +30,13 @@ pub fn epsilon_eq(a: f32, b: f32, epsilon: f32) -> bool {
     diff < epsilon && diff > -epsilon
 }
 
-
 pub struct SharedResourcesBuilder {
     builtin_entity_parser: Arc<BuiltinEntityParser>,
     custom_entity_parser: Arc<CustomEntityParser>,
     gazetteers: HashMap<String, Arc<Gazetteer>>,
     stemmer: Option<Arc<Stemmer>>,
     word_clusterers: HashMap<String, Arc<WordClusterer>>,
-    stop_words: HashSet<String>
+    stop_words: HashSet<String>,
 }
 
 impl Default for SharedResourcesBuilder {
@@ -48,7 +47,7 @@ impl Default for SharedResourcesBuilder {
             gazetteers: HashMap::default(),
             stemmer: None,
             word_clusterers: HashMap::default(),
-            stop_words: HashSet::default()
+            stop_words: HashSet::default(),
         }
     }
 }
@@ -76,14 +75,14 @@ impl SharedResourcesBuilder {
             gazetteers: self.gazetteers,
             stemmer: self.stemmer,
             word_clusterers: self.word_clusterers,
-            stop_words: self.stop_words
+            stop_words: self.stop_words,
         }
     }
 }
 
 #[derive(Default)]
 pub struct MockedBuiltinEntityParser {
-    pub mocked_outputs: HashMap<String, Vec<BuiltinEntity>>
+    pub mocked_outputs: HashMap<String, Vec<BuiltinEntity>>,
 }
 
 impl BuiltinEntityParser for MockedBuiltinEntityParser {
@@ -93,21 +92,21 @@ impl BuiltinEntityParser for MockedBuiltinEntityParser {
         _filter_entity_kinds: Option<&[BuiltinEntityKind]>,
         _use_cache: bool,
     ) -> Result<Vec<BuiltinEntity>> {
-        Ok(self.mocked_outputs.get(sentence)
-            .cloned()
-            .unwrap_or(vec![]))
+        Ok(self.mocked_outputs.get(sentence).cloned().unwrap_or(vec![]))
     }
 }
 
 impl FromIterator<(String, Vec<BuiltinEntity>)> for MockedBuiltinEntityParser {
-    fn from_iter<T: IntoIterator<Item=(String, Vec<BuiltinEntity>)>>(iter: T) -> Self {
-        Self { mocked_outputs: HashMap::from_iter(iter) }
+    fn from_iter<T: IntoIterator<Item = (String, Vec<BuiltinEntity>)>>(iter: T) -> Self {
+        Self {
+            mocked_outputs: HashMap::from_iter(iter),
+        }
     }
 }
 
 #[derive(Default)]
 pub struct MockedCustomEntityParser {
-    pub mocked_outputs: HashMap<String, Vec<CustomEntity>>
+    pub mocked_outputs: HashMap<String, Vec<CustomEntity>>,
 }
 
 impl CustomEntityParser for MockedCustomEntityParser {
@@ -116,14 +115,14 @@ impl CustomEntityParser for MockedCustomEntityParser {
         sentence: &str,
         _filter_entity_kinds: Option<&[String]>,
     ) -> Result<Vec<CustomEntity>> {
-        Ok(self.mocked_outputs.get(sentence)
-            .cloned()
-            .unwrap_or(vec![]))
+        Ok(self.mocked_outputs.get(sentence).cloned().unwrap_or(vec![]))
     }
 }
 
 impl FromIterator<(String, Vec<CustomEntity>)> for MockedCustomEntityParser {
-    fn from_iter<T: IntoIterator<Item=(String, Vec<CustomEntity>)>>(iter: T) -> Self {
-        Self { mocked_outputs: HashMap::from_iter(iter) }
+    fn from_iter<T: IntoIterator<Item = (String, Vec<CustomEntity>)>>(iter: T) -> Self {
+        Self {
+            mocked_outputs: HashMap::from_iter(iter),
+        }
     }
 }

--- a/snips-nlu-lib/src/utils.rs
+++ b/snips-nlu-lib/src/utils.rs
@@ -2,8 +2,8 @@ use std::fs;
 use std::io;
 use std::path::{Component, Path, PathBuf};
 
-use zip::ZipArchive;
 use failure::ResultExt;
+use zip::ZipArchive;
 
 use crate::errors::*;
 
@@ -37,15 +37,22 @@ pub fn product<'a, T>(v: &'a [&'a [T]]) -> Vec<Vec<&'a T>> {
 pub fn deduplicate_overlapping_items<I, O, S, K>(
     items: Vec<I>,
     overlap: O,
-    sort_key_fn: S
+    sort_key_fn: S,
 ) -> Vec<I>
-    where I: Clone, O: Fn(&I, &I) -> bool, S: FnMut(&I) -> K, K: Ord
+where
+    I: Clone,
+    O: Fn(&I, &I) -> bool,
+    S: FnMut(&I) -> K,
+    K: Ord,
 {
     let mut sorted_items = items.clone();
     sorted_items.sort_by_key(sort_key_fn);
     let mut deduplicated_items: Vec<I> = Vec::with_capacity(items.len());
     for item in sorted_items {
-        if !deduplicated_items.iter().any(|dedup_item| overlap(dedup_item, &item)) {
+        if !deduplicated_items
+            .iter()
+            .any(|dedup_item| overlap(dedup_item, &item))
+        {
             deduplicated_items.push(item);
         }
     }
@@ -54,10 +61,10 @@ pub fn deduplicate_overlapping_items<I, O, S, K>(
 
 pub fn extract_nlu_engine_zip_archive<R: io::Read + io::Seek>(
     zip_reader: R,
-    dest_path: &Path
+    dest_path: &Path,
 ) -> Result<PathBuf> {
-    let mut archive = ZipArchive::new(zip_reader)
-        .with_context(|_| "Could not read nlu engine zip data")?;
+    let mut archive =
+        ZipArchive::new(zip_reader).with_context(|_| "Could not read nlu engine zip data")?;
     for file_index in 0..archive.len() {
         let mut file = archive.by_index(file_index)?;
         let outpath = dest_path.join(file.sanitized_name());
@@ -74,12 +81,16 @@ pub fn extract_nlu_engine_zip_archive<R: io::Read + io::Seek>(
             io::copy(&mut file, &mut outfile)?;
         }
     }
-    let first_archive_file = archive
-        .by_index(0)?
-        .sanitized_name();
+    let first_archive_file = archive.by_index(0)?.sanitized_name();
     let engine_dir_path = first_archive_file
         .components()
-        .find(|component| if let Component::Normal(_) = component { true } else { false })
+        .find(|component| {
+            if let Component::Normal(_) = component {
+                true
+            } else {
+                false
+            }
+        })
         .ok_or_else(|| format_err!("Trained engine archive is incorrect"))?
         .as_os_str();
     let engine_dir_name = engine_dir_path
@@ -92,9 +103,9 @@ pub fn extract_nlu_engine_zip_archive<R: io::Read + io::Seek>(
 mod tests {
     use super::*;
     use itertools::repeat_n;
+    use nlu_utils::range::ranges_overlap;
     use std::collections::HashSet;
     use std::ops::Range;
-    use nlu_utils::range::ranges_overlap;
 
     #[test]
     fn product_works() {
@@ -129,12 +140,7 @@ mod tests {
     #[test]
     fn test_deduplicate_items_works() {
         // Given
-        let items = vec![
-            0..3,
-            4..8,
-            0..8,
-            9..13
-        ];
+        let items = vec![0..3, 4..8, 0..8, 9..13];
 
         fn sort_key(rng: &Range<usize>) -> i32 {
             -(rng.clone().count() as i32)

--- a/snips-nlu-lib/src/utils.rs
+++ b/snips-nlu-lib/src/utils.rs
@@ -1,10 +1,11 @@
 use std::fs;
 use std::io;
 use std::path::{Component, Path, PathBuf};
-use zip::ZipArchive;
 
-use errors::*;
+use zip::ZipArchive;
 use failure::ResultExt;
+
+use crate::errors::*;
 
 pub type IntentName = String;
 pub type SlotName = String;


### PR DESCRIPTION
Update repo to use 2018 edition of Rust.

No logical changes here, the principal issue was the declaration/usage of internal modules.

In addition of this change, I've fixed some clippy issues and brung back the `Cargo.toml` workspace as we don't depend anymore on this crate by submodule (no more workspace conflicts).