### PR TITLE
Remove normalization of confidence scores in intent classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Fixed
 - Fix handling of ambiguous utterances in `DeterministicIntentParser`
+- Stop normalizing confidence scores when there is an intents filter
 
 ## [0.64.1] - 2019-03-01
 ### Fixed


### PR DESCRIPTION
**Description**
The logreg intent classifier used to have a specific logic when used with an intents filter: the intent classification scores were renormalized to sum to 1.0.

This could lead to unexpected behaviors, especially when all the intents in the intents filter are associated to very low confidence scores. In such cases, the renormalization would significantly increase the scores.