### PR TITLE
Add new APIs in ffi and bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Fixed
-- Fix handling of ambiguous utterances in `DeterministicIntentParser`
-- Stop normalizing confidence scores when there is an intents filter
+- Fix handling of ambiguous utterances in `DeterministicIntentParser` [#129](https://github.com/snipsco/snips-nlu-rs/pull/129)
+- Stop normalizing confidence scores when there is an intents filter [#130](https://github.com/snipsco/snips-nlu-rs/pull/130)
+
+### Added
+- Add new APIs in ffi and bindings (python, kotlin, swift) [#131](https://github.com/snipsco/snips-nlu-rs/pull/131)
 
 ## [0.64.1] - 2019-03-01
 ### Fixed
-- Fix bug with regex patterns containing duplicated slot names
+- Fix bug with regex patterns containing duplicated slot names [#124](https://github.com/snipsco/snips-nlu-rs/pull/124)
 
 ## [0.64.0] - 2019-02-28
 ### Changed
@@ -17,7 +20,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.63.1] - 2019-02-11
 ### Fixed
-- Fix an issue regarding the way builtin entities were handled by the `CRFSlotFiller`
+- Fix an issue regarding the way builtin entities were handled by the `CRFSlotFiller` [#116](https://github.com/snipsco/snips-nlu-rs/pull/116)
 
 ## [0.63.0] - 2019-02-04
 ### Added
@@ -183,6 +186,7 @@ being statically hardcoded, reducing the binary size by 31Mb.
 - Improve support for japanese
 - Rename python package to `snips_nlu_rust`
 
+[Unreleased]: https://github.com/snipsco/snips-nlu-rs/compare/0.64.1...HEAD
 [0.64.1]: https://github.com/snipsco/snips-nlu-rs/compare/0.64.0...0.64.1
 [0.64.0]: https://github.com/snipsco/snips-nlu-rs/compare/0.63.1...0.64.0
 [0.63.1]: https://github.com/snipsco/snips-nlu-rs/compare/0.63.0...0.63.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 [dependencies]
 crfsuite = { git = "https://github.com/snipsco/crfsuite-rs", tag = "0.3.1" }
 snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.64.6" }
-snips-nlu-parsers = { git = "https://github.com/snipsco/snips-nlu-parsers", tag = "0.2.0" }
+snips-nlu-parsers = { git = "https://github.com/snipsco/snips-nlu-parsers", tag = "0.2.1" }
 snips-nlu-utils = { git = "https://github.com/snipsco/snips-nlu-utils", tag = "0.8.0" }
 failure = "0.1"
 base64 = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 
 [dependencies]
 crfsuite = { git = "https://github.com/snipsco/crfsuite-rs", tag = "0.3.1" }
-snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.64.4" }
+snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.64.6" }
 snips-nlu-parsers = { git = "https://github.com/snipsco/snips-nlu-parsers", tag = "0.2.0" }
 snips-nlu-utils = { git = "https://github.com/snipsco/snips-nlu-utils", tag = "0.8.0" }
 failure = "0.1"

--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ the `Snips NLU python library <https://github.com/snipsco/snips-nlu>`_.
 Example and API Usage
 ---------------------
 
-The `interactive parsing CLI <snips-nlu-lib/examples/interactive_parsing_cli>`_  is a good example
+The `interactive parsing CLI <examples/interactive_parsing_cli>`_  is a good example
 of to how to use ``snips-nlu-rs``.
 
 Here is how you can run the CLI example:
@@ -75,7 +75,8 @@ Here is how you can run the CLI example:
 .. code-block:: bash
 
    $ git clone https://github.com/snipsco/snips-nlu-rs
-   $ cargo run -p snips-nlu-lib --example interactive_parsing_cli data/tests/models/nlu_engine
+   $ cd snips-nlu-rs
+   $ cargo run --example interactive_parsing_cli data/tests/models/nlu_engine
 
 Here we used a sample trained engine, which consists in two intents: ``MakeCoffee`` and ``MakeTea``.
 Thus, it will be able to parse queries like ``"Make me two cups of coffee please"`` or ``"I'd like a hot tea"``.

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -12,7 +12,7 @@ authors = [
 [dependencies]
 ffi-utils = { git = "https://github.com/snipsco/snips-utils-rs", rev = "4292ad9" }
 snips-nlu-lib = { path = ".." }
-snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.64.4" }
+snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.64.6" }
 failure = "0.1"
 lazy_static = "1.0"
 libc = "0.2"

--- a/ffi/cbindgen.toml
+++ b/ffi/cbindgen.toml
@@ -2,15 +2,20 @@ language = "c"
 
 include_guard = "LIBSNIPS_NLU_H_"
 
-header = "#define SNIPS_NLU_VERSION \"0.62.0-SNAPSHOT\""
+header = "#define SNIPS_NLU_VERSION \"0.65.0-SNAPSHOT\""
 
 [parse]
-parse_deps=true
+parse_deps = true
 include = [
     "snips_nlu_ffi",
     "ffi_utils",
     "snips_nlu_ontology_ffi",
     "snips_nlu_ontology_ffi_macros",
+]
+
+[parse.expand]
+crates = [
+    "snips-nlu-ffi",
 ]
 
 [export]

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -11,7 +11,7 @@ use std::sync::Mutex;
 use failure::{format_err, ResultExt};
 use ffi_utils::*;
 use snips_nlu_lib::SnipsNluEngine;
-use snips_nlu_ontology_ffi_macros::{CIntentClassifierResultList, CIntentParserResult, CSlotList};
+use snips_nlu_ontology_ffi_macros::{CIntentClassifierResultArray, CIntentParserResult, CSlotList};
 
 type Result<T> = std::result::Result<T, failure::Error>;
 
@@ -76,7 +76,7 @@ pub extern "C" fn snips_nlu_engine_run_get_slots(
 pub extern "C" fn snips_nlu_engine_run_get_intents(
     client: *const CSnipsNluEngine,
     input: *const libc::c_char,
-    result: *mut *const CIntentClassifierResultList,
+    result: *mut *const CIntentClassifierResultArray,
 ) -> SNIPS_RESULT {
     wrap!(run_get_intents(client, input, result))
 }
@@ -141,9 +141,9 @@ pub extern "C" fn snips_nlu_engine_destroy_slots(result: *mut CSlotList) -> SNIP
 
 #[no_mangle]
 pub extern "C" fn snips_nlu_engine_destroy_intent_classifier_results(
-    result: *mut CIntentClassifierResultList,
+    result: *mut CIntentClassifierResultArray,
 ) -> SNIPS_RESULT {
-    wrap!(unsafe { CIntentClassifierResultList::from_raw_pointer(result) })
+    wrap!(unsafe { CIntentClassifierResultArray::from_raw_pointer(result) })
 }
 
 #[no_mangle]
@@ -231,13 +231,13 @@ fn run_get_slots(
 fn run_get_intents(
     client: *const CSnipsNluEngine,
     input: *const libc::c_char,
-    result: *mut *const CIntentClassifierResultList,
+    result: *mut *const CIntentClassifierResultArray,
 ) -> Result<()> {
     let input = create_rust_string_from!(input);
     let nlu_engine = get_nlu_engine!(client);
 
     let intents = nlu_engine.get_intents(&input)?;
-    let raw_pointer = CIntentClassifierResultList::from(intents).into_raw_pointer();
+    let raw_pointer = CIntentClassifierResultArray::from(intents).into_raw_pointer();
 
     unsafe { *result = raw_pointer };
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1,15 +1,17 @@
 #![allow(non_camel_case_types)]
 
-use std::ffi::CString;
+extern crate ffi_utils;
+extern crate snips_nlu_ontology_ffi_macros;
+
+use std::ffi::{CStr, CString};
 use std::io::Cursor;
 use std::slice;
 use std::sync::Mutex;
 
 use failure::{format_err, ResultExt};
+use ffi_utils::*;
 use snips_nlu_lib::SnipsNluEngine;
 use snips_nlu_ontology_ffi_macros::CIntentParserResult;
-
-use ffi_utils::*;
 
 type Result<T> = std::result::Result<T, failure::Error>;
 
@@ -47,18 +49,34 @@ pub extern "C" fn snips_nlu_engine_create_from_zip(
 pub extern "C" fn snips_nlu_engine_run_parse(
     client: *const CSnipsNluEngine,
     input: *const libc::c_char,
+    intents_whitelist: *const CStringArray,
+    intents_blacklist: *const CStringArray,
     result: *mut *const CIntentParserResult,
 ) -> SNIPS_RESULT {
-    wrap!(run_parse(client, input, result))
+    wrap!(run_parse(
+        client,
+        input,
+        intents_whitelist,
+        intents_blacklist,
+        result
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn snips_nlu_engine_run_parse_into_json(
     client: *const CSnipsNluEngine,
     input: *const libc::c_char,
+    intents_whitelist: *const CStringArray,
+    intents_blacklist: *const CStringArray,
     result_json: *mut *const libc::c_char,
 ) -> SNIPS_RESULT {
-    wrap!(run_parse_into_json(client, input, result_json))
+    wrap!(run_parse_into_json(
+        client,
+        input,
+        intents_whitelist,
+        intents_blacklist,
+        result_json
+    ))
 }
 
 #[no_mangle]
@@ -116,12 +134,25 @@ fn create_from_zip(
 fn run_parse(
     client: *const CSnipsNluEngine,
     input: *const libc::c_char,
+    intents_whitelist: *const CStringArray,
+    intents_blacklist: *const CStringArray,
     result: *mut *const CIntentParserResult,
 ) -> Result<()> {
     let input = create_rust_string_from!(input);
     let nlu_engine = get_nlu_engine!(client);
 
-    let results = nlu_engine.parse(&input, None, None)?;
+    let opt_whitelist: Option<Vec<_>> = if !intents_whitelist.is_null() {
+        Some(unsafe { convert_to_rust_vec(intents_whitelist)? })
+    } else {
+        None
+    };
+    let opt_blacklist: Option<Vec<_>> = if !intents_blacklist.is_null() {
+        Some(unsafe { convert_to_rust_vec(intents_blacklist)? })
+    } else {
+        None
+    };
+
+    let results = nlu_engine.parse(&input, opt_whitelist, opt_blacklist)?;
     let raw_pointer = CIntentParserResult::from(results).into_raw_pointer();
 
     unsafe { *result = raw_pointer };
@@ -132,16 +163,36 @@ fn run_parse(
 fn run_parse_into_json(
     client: *const CSnipsNluEngine,
     input: *const libc::c_char,
+    intents_whitelist: *const CStringArray,
+    intents_blacklist: *const CStringArray,
     result_json: *mut *const libc::c_char,
 ) -> Result<()> {
     let input = create_rust_string_from!(input);
     let nlu_engine = get_nlu_engine!(client);
 
-    let results = nlu_engine.parse(&input, None, None)?;
+    let opt_whitelist: Option<Vec<_>> = if !intents_whitelist.is_null() {
+        Some(unsafe { convert_to_rust_vec(intents_whitelist)? })
+    } else {
+        None
+    };
+    let opt_blacklist: Option<Vec<_>> = if !intents_blacklist.is_null() {
+        Some(unsafe { convert_to_rust_vec(intents_blacklist)? })
+    } else {
+        None
+    };
+    let results = nlu_engine.parse(&input, opt_whitelist, opt_blacklist)?;
 
     point_to_string(result_json, serde_json::to_string(&results)?)
 }
 
 fn get_model_version(version: *mut *const libc::c_char) -> Result<()> {
     point_to_string(version, snips_nlu_lib::MODEL_VERSION.to_string())
+}
+
+unsafe fn convert_to_rust_vec<'a>(c_array: *const CStringArray) -> Result<Vec<&'a str>> {
+    let array = &*c_array;
+    slice::from_raw_parts(array.data, array.size as usize)
+        .into_iter()
+        .map(|&ptr| Ok(CStr::from_ptr(ptr).to_str().map_err(failure::Error::from)?))
+        .collect::<Result<Vec<_>>>()
 }

--- a/platforms/c/libsnips_nlu.h
+++ b/platforms/c/libsnips_nlu.h
@@ -145,6 +145,20 @@ typedef struct {
 } CIntentClassifierResult;
 
 /**
+ * Wrapper around a list of IntentClassifierResult
+ */
+typedef struct {
+  /**
+   * Pointer to the first result of the list
+   */
+  const CIntentClassifierResult *intent_classifier_results;
+  /**
+   * Number of results in the list
+   */
+  int32_t size;
+} CIntentClassifierResultList;
+
+/**
  * A slot value
  */
 typedef struct {
@@ -369,11 +383,39 @@ SNIPS_RESULT snips_nlu_engine_create_from_zip(const unsigned char *zip,
 
 SNIPS_RESULT snips_nlu_engine_destroy_client(CSnipsNluEngine *client);
 
+SNIPS_RESULT snips_nlu_engine_destroy_intent_classifier_results(CIntentClassifierResultList *result);
+
 SNIPS_RESULT snips_nlu_engine_destroy_result(CIntentParserResult *result);
+
+SNIPS_RESULT snips_nlu_engine_destroy_slots(CSlotList *result);
 
 SNIPS_RESULT snips_nlu_engine_destroy_string(char *string);
 
+/**
+ * Used to retrieve the last error that happened in this thread. A function encountered an
+ * error if its return type is of type SNIPS_RESULT and it returned SNIPS_RESULT_KO
+ */
+SNIPS_RESULT snips_nlu_engine_get_last_error(const char **error);
+
 SNIPS_RESULT snips_nlu_engine_get_model_version(const char **version);
+
+SNIPS_RESULT snips_nlu_engine_run_get_intents(const CSnipsNluEngine *client,
+                                              const char *input,
+                                              const CIntentClassifierResultList **result);
+
+SNIPS_RESULT snips_nlu_engine_run_get_intents_into_json(const CSnipsNluEngine *client,
+                                                        const char *input,
+                                                        const char **result_json);
+
+SNIPS_RESULT snips_nlu_engine_run_get_slots(const CSnipsNluEngine *client,
+                                            const char *input,
+                                            const char *intent,
+                                            const CSlotList **result);
+
+SNIPS_RESULT snips_nlu_engine_run_get_slots_into_json(const CSnipsNluEngine *client,
+                                                      const char *input,
+                                                      const char *intent,
+                                                      const char **result_json);
 
 SNIPS_RESULT snips_nlu_engine_run_parse(const CSnipsNluEngine *client,
                                         const char *input,
@@ -386,7 +428,5 @@ SNIPS_RESULT snips_nlu_engine_run_parse_into_json(const CSnipsNluEngine *client,
                                                   const CStringArray *intents_whitelist,
                                                   const CStringArray *intents_blacklist,
                                                   const char **result_json);
-
-SNIPS_RESULT snips_nlu_engine_get_last_error(char **error);
 
 #endif /* LIBSNIPS_NLU_H_ */

--- a/platforms/c/libsnips_nlu.h
+++ b/platforms/c/libsnips_nlu.h
@@ -1,127 +1,128 @@
+#define SNIPS_NLU_VERSION "0.65.0-SNAPSHOT"
+
 #ifndef LIBSNIPS_NLU_H_
 #define LIBSNIPS_NLU_H_
 
+#include <stdarg.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <stdbool.h>
 
-#define SNIPS_NLU_VERSION "0.65.0-SNAPSHOT"
-
-/*
+/**
  * Enum representing the grain of a resolved date related value
  */
 typedef enum {
-  /*
+  /**
    * The resolved value has a granularity of a year
    */
   SNIPS_GRAIN_YEAR = 0,
-  /*
+  /**
    * The resolved value has a granularity of a quarter
    */
   SNIPS_GRAIN_QUARTER = 1,
-  /*
+  /**
    * The resolved value has a granularity of a mount
    */
   SNIPS_GRAIN_MONTH = 2,
-  /*
+  /**
    * The resolved value has a granularity of a week
    */
   SNIPS_GRAIN_WEEK = 3,
-  /*
+  /**
    * The resolved value has a granularity of a day
    */
   SNIPS_GRAIN_DAY = 4,
-  /*
+  /**
    * The resolved value has a granularity of an hour
    */
   SNIPS_GRAIN_HOUR = 5,
-  /*
+  /**
    * The resolved value has a granularity of a minute
    */
   SNIPS_GRAIN_MINUTE = 6,
-  /*
+  /**
    * The resolved value has a granularity of a second
    */
   SNIPS_GRAIN_SECOND = 7,
 } SNIPS_GRAIN;
 
-/*
+/**
  * Enum describing the precision of a resolved value
  */
 typedef enum {
-  /*
+  /**
    * The resolved value is approximate
    */
   SNIPS_PRECISION_APPROXIMATE = 0,
-  /*
+  /**
    * The resolved value is exact
    */
   SNIPS_PRECISION_EXACT = 1,
 } SNIPS_PRECISION;
 
-/*
+/**
  * Used as a return type of functions that can encounter errors
  */
 typedef enum {
-  /*
+  /**
    * The function returned successfully
    */
   SNIPS_RESULT_OK = 0,
-  /*
+  /**
    * The function encountered an error, you can retrieve it using the dedicated function
    */
   SNIPS_RESULT_KO = 1,
 } SNIPS_RESULT;
 
-/*
+/**
  * Enum type describing how to cast the value of a CSlotValue
  */
 typedef enum {
-  /*
+  /**
    * Custom type represented by a char *
    */
   SNIPS_SLOT_VALUE_TYPE_CUSTOM = 1,
-  /*
+  /**
    * Number type represented by a CNumberValue
    */
   SNIPS_SLOT_VALUE_TYPE_NUMBER = 2,
-  /*
+  /**
    * Ordinal type represented by a COrdinalValue
    */
   SNIPS_SLOT_VALUE_TYPE_ORDINAL = 3,
-  /*
+  /**
    * Instant type represented by a CInstantTimeValue
    */
   SNIPS_SLOT_VALUE_TYPE_INSTANTTIME = 4,
-  /*
+  /**
    * Interval type represented by a CTimeIntervalValue
    */
   SNIPS_SLOT_VALUE_TYPE_TIMEINTERVAL = 5,
-  /*
+  /**
    * Amount of money type represented by a CAmountOfMoneyValue
    */
   SNIPS_SLOT_VALUE_TYPE_AMOUNTOFMONEY = 6,
-  /*
+  /**
    * Temperature type represented by a CTemperatureValue
    */
   SNIPS_SLOT_VALUE_TYPE_TEMPERATURE = 7,
-  /*
+  /**
    * Duration type represented by a CDurationValue
    */
   SNIPS_SLOT_VALUE_TYPE_DURATION = 8,
-  /*
+  /**
    * Percentage type represented by a CPercentageValue
    */
   SNIPS_SLOT_VALUE_TYPE_PERCENTAGE = 9,
-  /*
+  /**
    * Music Album type represented by a char *
    */
   SNIPS_SLOT_VALUE_TYPE_MUSICALBUM = 10,
-  /*
+  /**
    * Music Artist type represented by a char *
    */
   SNIPS_SLOT_VALUE_TYPE_MUSICARTIST = 11,
-  /*
+  /**
    * Music Track type represented by a char *
    */
   SNIPS_SLOT_VALUE_TYPE_MUSICTRACK = 12,
@@ -129,218 +130,232 @@ typedef enum {
 
 typedef struct CSnipsNluEngine CSnipsNluEngine;
 
-/*
+/**
  * Results of the intent classifier
  */
 typedef struct {
-  /*
+  /**
    * Name of the intent detected
    */
   const char *intent_name;
-  /*
+  /**
    * Between 0 and 1
    */
-  float probability;
+  float confidence_score;
 } CIntentClassifierResult;
 
-/*
+/**
  * A slot value
  */
 typedef struct {
-  /*
+  /**
    * Points to either a *const char, a CNumberValue, a COrdinalValue,
    * a CInstantTimeValue, a CTimeIntervalValue, a CAmountOfMoneyValue,
    * a CTemperatureValue or a CDurationValue depending on value_type
    */
   const void *value;
-  /*
+  /**
    * The type of the value
    */
   SNIPS_SLOT_VALUE_TYPE value_type;
 } CSlotValue;
 
-/*
+/**
  * Struct describing a Slot
  */
 typedef struct {
-  /*
+  /**
    * The resolved value of the slot
    */
   CSlotValue value;
-  /*
+  /**
    * The raw value as it appears in the input text
    */
   const char *raw_value;
-  /*
+  /**
    * Name of the entity type of the slot
    */
   const char *entity;
-  /*
+  /**
    * Name of the slot
    */
   const char *slot_name;
-  /*
+  /**
    * Start index of raw value in input text
    */
   int32_t range_start;
-  /*
+  /**
    * End index of raw value in input text
    */
   int32_t range_end;
-  /*
+  /**
    * Confidence score of the slot
    */
   float confidence_score;
 } CSlot;
 
-/*
+/**
  * Wrapper around a slot list
  */
 typedef struct {
-  /*
+  /**
    * Pointer to the first slot of the list
    */
   const CSlot *slots;
-  /*
+  /**
    * Number of slots in the list
    */
   int32_t size;
 } CSlotList;
 
-/*
- * Results of intent parsing
+/**
+ * Result of intent parsing
  */
 typedef struct {
-  /*
+  /**
    * The text that was parsed
    */
   const char *input;
-  /*
-   * The result of intent classification, may be null if no intent was detected
+  /**
+   * The result of intent classification
    */
   const CIntentClassifierResult *intent;
-  /*
-   * The slots extracted if an intent was detected
+  /**
+   * The slots extracted
    */
   const CSlotList *slots;
 } CIntentParserResult;
 
-/*
+/**
+ * An array of strings
+ */
+typedef struct {
+  /**
+   * Pointer to the first element of the array
+   */
+  const char *const *data;
+  /**
+   * Number of elements in the array
+   */
+  int size;
+} CStringArray;
+
+/**
  * Representation of a number value
  */
 typedef double CNumberValue;
 
-/*
+/**
  * Representation of an ordinal value
  */
 typedef int64_t COrdinalValue;
 
-/*
+/**
  * Representation of a percentage value
  */
 typedef double CPercentageValue;
 
-/*
+/**
  * Representation of an instant value
  */
 typedef struct {
-  /*
+  /**
    * String representation of the instant
    */
   const char *value;
-  /*
+  /**
    * The grain of the resolved instant
    */
   SNIPS_GRAIN grain;
-  /*
+  /**
    * The precision of the resolved instant
    */
   SNIPS_PRECISION precision;
 } CInstantTimeValue;
 
-/*
+/**
  * Representation of an interval value
  */
 typedef struct {
-  /*
+  /**
    * String representation of the beginning of the interval
    */
   const char *from;
-  /*
+  /**
    * String representation of the end of the interval
    */
   const char *to;
 } CTimeIntervalValue;
 
-/*
+/**
  * Representation of an amount of money value
  */
 typedef struct {
-  /*
+  /**
    * The currency
    */
   const char *unit;
-  /*
+  /**
    * The amount of money
    */
   float value;
-  /*
+  /**
    * The precision of the resolved value
    */
   SNIPS_PRECISION precision;
 } CAmountOfMoneyValue;
 
-/*
+/**
  * Representation of a temperature value
  */
 typedef struct {
-  /*
+  /**
    * The unit used
    */
   const char *unit;
-  /*
+  /**
    * The temperature resolved
    */
   float value;
 } CTemperatureValue;
 
-/*
+/**
  * Representation of a duration value
  */
 typedef struct {
-  /*
+  /**
    * Number of years in the duration
    */
   int64_t years;
-  /*
+  /**
    * Number of quarters in the duration
    */
   int64_t quarters;
-  /*
+  /**
    * Number of months in the duration
    */
   int64_t months;
-  /*
+  /**
    * Number of weeks in the duration
    */
   int64_t weeks;
-  /*
+  /**
    * Number of days in the duration
    */
   int64_t days;
-  /*
+  /**
    * Number of hours in the duration
    */
   int64_t hours;
-  /*
+  /**
    * Number of minutes in the duration
    */
   int64_t minutes;
-  /*
+  /**
    * Number of seconds in the duration
    */
   int64_t seconds;
-  /*
+  /**
    * Precision of the resolved value
    */
   SNIPS_PRECISION precision;
@@ -362,10 +377,14 @@ SNIPS_RESULT snips_nlu_engine_get_model_version(const char **version);
 
 SNIPS_RESULT snips_nlu_engine_run_parse(const CSnipsNluEngine *client,
                                         const char *input,
+                                        const CStringArray *intents_whitelist,
+                                        const CStringArray *intents_blacklist,
                                         const CIntentParserResult **result);
 
 SNIPS_RESULT snips_nlu_engine_run_parse_into_json(const CSnipsNluEngine *client,
                                                   const char *input,
+                                                  const CStringArray *intents_whitelist,
+                                                  const CStringArray *intents_blacklist,
                                                   const char **result_json);
 
 SNIPS_RESULT snips_nlu_engine_get_last_error(char **error);

--- a/platforms/kotlin/build.gradle
+++ b/platforms/kotlin/build.gradle
@@ -32,7 +32,7 @@ configurations {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
     compile 'net.java.dev.jna:jna:4.5.0'
-    compile "ai.snips:snips-nlu-ontology:0.64.4"
+    compile "ai.snips:snips-nlu-ontology:0.64.6"
     testCompile 'junit:junit:4.12'
     testCompile 'com.google.truth:truth:0.36'
 }

--- a/platforms/kotlin/src/main/kotlin/ai/snips/nlu/NluEngine.kt
+++ b/platforms/kotlin/src/main/kotlin/ai/snips/nlu/NluEngine.kt
@@ -5,12 +5,48 @@ import ai.snips.nlu.ontology.ffi.CIntentParserResult
 import ai.snips.nlu.ontology.ffi.readString
 import ai.snips.nlu.ontology.ffi.toPointer
 import com.sun.jna.Library
+import com.sun.jna.Memory
 import com.sun.jna.Native
 import com.sun.jna.Pointer
 import com.sun.jna.ptr.PointerByReference
+import com.sun.jna.Structure
+import com.sun.jna.toJnaPointer
 import java.io.Closeable
 import java.io.File
 import ai.snips.nlu.NluEngine.SnipsNluClientLibrary.Companion.INSTANCE as LIB
+
+class CStringArray(p: Pointer?) : Structure(p), Structure.ByReference {
+    companion object {
+        @JvmStatic
+        fun fromStringList(list: List<String>) = CStringArray(null).apply {
+            size = list.size
+            data = if (size > 0)
+                Memory(Pointer.SIZE * list.size.toLong()).apply {
+                    list.forEachIndexed { i, s ->
+                        this.setPointer(i.toLong() * Pointer.SIZE, s.toPointer())
+                    }
+                }
+            else null
+        }
+    }
+
+    @JvmField
+    var data: Pointer? = null
+    @JvmField
+    var size: Int = -1
+
+    // be careful this block must be below the field definition if you don't want the native values read by JNA
+    // overridden by the default ones
+    init {
+        read()
+    }
+
+    override fun getFieldOrder() = listOf("data", "size")
+
+    fun toStringList() = if (size > 0) {
+        data!!.getPointerArray(0, size).map { it.readString() }
+    } else listOf<String>()
+}
 
 class NluEngine private constructor(clientBuilder: () -> Pointer) : Closeable {
 
@@ -53,9 +89,19 @@ class NluEngine private constructor(clientBuilder: () -> Pointer) : Closeable {
         LIB.snips_nlu_engine_destroy_client(client)
     }
 
-    fun parse(input: String): IntentParserResult =
+    fun parse(input: String): IntentParserResult = parse(input, null, null)
+
+    fun parse(input: String,
+              intentsWhitelist: List<String>?,
+              intentsBlacklist: List<String>?): IntentParserResult =
             CIntentParserResult(PointerByReference().apply {
-                parseError(LIB.snips_nlu_engine_run_parse(client, input.toPointer(), this))
+                parseError(LIB.snips_nlu_engine_run_parse(
+                        client,
+                        input.toPointer(),
+                        intentsWhitelist?.let { CStringArray.fromStringList(it) },
+                        intentsBlacklist?.let { CStringArray.fromStringList(it) },
+                        this
+                ))
             }.value).let {
                 it.toIntentParserResult().apply {
                     // we don't want jna to try and sync this struct after the call as we're destroying it
@@ -65,9 +111,19 @@ class NluEngine private constructor(clientBuilder: () -> Pointer) : Closeable {
                 }
             }
 
-    fun parseIntoJson(input: String): String =
+    fun parseIntoJson(input: String): String = parseIntoJson(input, null, null)
+
+    fun parseIntoJson(input: String,
+                      intentsWhitelist: List<String>?,
+                      intentsBlacklist: List<String>?): String =
             PointerByReference().apply {
-                parseError(LIB.snips_nlu_engine_run_parse_into_json(client, input.toPointer(), this))
+                parseError(LIB.snips_nlu_engine_run_parse_into_json(
+                        client,
+                        input.toPointer(),
+                        intentsWhitelist?.let { CStringArray.fromStringList(it) },
+                        intentsBlacklist?.let { CStringArray.fromStringList(it) },
+                        this
+                ))
             }.value.let {
                 it.readString().apply {
                     LIB.snips_nlu_engine_destroy_string(it)
@@ -82,8 +138,17 @@ class NluEngine private constructor(clientBuilder: () -> Pointer) : Closeable {
         fun snips_nlu_engine_get_model_version(version: PointerByReference): Int
         fun snips_nlu_engine_create_from_dir(root_dir: Pointer, pointer: PointerByReference): Int
         fun snips_nlu_engine_create_from_zip(data: ByteArray, data_size: Int, pointer: PointerByReference): Int
-        fun snips_nlu_engine_run_parse(client: Pointer, input: Pointer, result: PointerByReference): Int
-        fun snips_nlu_engine_run_parse_into_json(client: Pointer, input: Pointer, result: PointerByReference): Int
+        fun snips_nlu_engine_run_parse(
+                client: Pointer, input: Pointer,
+                intents_whitelist: CStringArray?,
+                intents_blacklist: CStringArray?,
+                result: PointerByReference): Int
+        fun snips_nlu_engine_run_parse_into_json(
+                client: Pointer,
+                input: Pointer,
+                intents_whitelist: CStringArray?,
+                intents_blacklist: CStringArray?,
+                result: PointerByReference): Int
         fun snips_nlu_engine_get_last_error(error: PointerByReference): Int
         fun snips_nlu_engine_destroy_client(client: Pointer): Int
         fun snips_nlu_engine_destroy_result(result: CIntentParserResult): Int

--- a/platforms/kotlin/src/main/kotlin/ai/snips/nlu/NluEngine.kt
+++ b/platforms/kotlin/src/main/kotlin/ai/snips/nlu/NluEngine.kt
@@ -93,11 +93,9 @@ class NluEngine private constructor(clientBuilder: () -> Pointer) : Closeable {
         LIB.snips_nlu_engine_destroy_client(client)
     }
 
-    fun parse(input: String): IntentParserResult = parse(input, null, null)
-
     fun parse(input: String,
-              intentsWhitelist: List<String>?,
-              intentsBlacklist: List<String>?): IntentParserResult =
+              intentsWhitelist: List<String>? = null,
+              intentsBlacklist: List<String>? = null): IntentParserResult =
             CIntentParserResult(PointerByReference().apply {
                 parseError(LIB.snips_nlu_engine_run_parse(
                         client,
@@ -115,11 +113,9 @@ class NluEngine private constructor(clientBuilder: () -> Pointer) : Closeable {
                 }
             }
 
-    fun parseIntoJson(input: String): String = parseIntoJson(input, null, null)
-
     fun parseIntoJson(input: String,
-                      intentsWhitelist: List<String>?,
-                      intentsBlacklist: List<String>?): String =
+                      intentsWhitelist: List<String>? = null,
+                      intentsBlacklist: List<String>? = null): String =
             PointerByReference().apply {
                 parseError(LIB.snips_nlu_engine_run_parse_into_json(
                         client,

--- a/platforms/kotlin/src/test/kotlin/ai/snips/nlu/NluEngineTest.kt
+++ b/platforms/kotlin/src/test/kotlin/ai/snips/nlu/NluEngineTest.kt
@@ -37,6 +37,26 @@ class NluEngineTest {
     }
 
     @Test
+    fun parseWithWhitelistWorks() {
+        NluEngine(File("../../data/tests/models/nlu_engine")).use {
+            it.parse("make me two cups of hot tea", listOf("MakeCoffee"), null).apply {
+                assertThat(input).isEqualTo("make me two cups of hot tea")
+                assertThat(intent.intentName!!).isEqualTo("MakeCoffee")
+            }
+        }
+    }
+
+    @Test
+    fun parseWithBlacklistWorks() {
+        NluEngine(File("../../data/tests/models/nlu_engine")).use {
+            it.parse("make me two cups of hot tea", null, listOf("MakeTea")).apply {
+                assertThat(input).isEqualTo("make me two cups of hot tea")
+                assertThat(intent.intentName!!).isEqualTo("MakeCoffee")
+            }
+        }
+    }
+
+    @Test
     fun parseIntoJsonWorks() {
         NluEngine(File("../../data/tests/models/nlu_engine")).use {
             it.parseIntoJson("make me two cups of hot tea").apply {
@@ -45,6 +65,28 @@ class NluEngineTest {
                 assertThat(this).contains("MakeTea")
                 assertThat(this).contains("beverage_temperature")
                 assertThat(this).contains("number_of_cups")
+            }
+        }
+    }
+
+    @Test
+    fun parseIntoJsonWithWhitelistWorks() {
+        NluEngine(File("../../data/tests/models/nlu_engine")).use {
+            it.parseIntoJson("make me two cups of hot tea", listOf("MakeCoffee"), null).apply {
+                assertThat(this).isNotNull()
+                assertThat(this).contains("make me two cups of hot tea")
+                assertThat(this).contains("MakeCoffee")
+            }
+        }
+    }
+
+    @Test
+    fun parseIntoJsonWithBlakclistWorks() {
+        NluEngine(File("../../data/tests/models/nlu_engine")).use {
+            it.parseIntoJson("make me two cups of hot tea", null, listOf("MakeTea")).apply {
+                assertThat(this).isNotNull()
+                assertThat(this).contains("make me two cups of hot tea")
+                assertThat(this).contains("MakeCoffee")
             }
         }
     }

--- a/platforms/kotlin/src/test/kotlin/ai/snips/nlu/NluEngineTest.kt
+++ b/platforms/kotlin/src/test/kotlin/ai/snips/nlu/NluEngineTest.kt
@@ -92,6 +92,50 @@ class NluEngineTest {
     }
 
     @Test
+    fun getSlotsWorks() {
+        NluEngine(File("../../data/tests/models/nlu_engine")).use {
+            it.getSlots("make me two cups of hot tea", "MakeTea").apply {
+                assertThat(this).hasSize(2)
+                assertThat(this.map { it.slotName }).containsAllOf("beverage_temperature", "number_of_cups")
+            }
+        }
+    }
+
+    @Test
+    fun getSlotsIntoJsonWorks() {
+        NluEngine(File("../../data/tests/models/nlu_engine")).use {
+            it.getSlotsIntoJson("make me two cups of hot tea", "MakeTea").apply {
+                assertThat(this).isNotNull()
+                assertThat(this).contains("beverage_temperature")
+                assertThat(this).contains("number_of_cups")
+            }
+        }
+    }
+
+    @Test
+    fun getIntentsWorks() {
+        NluEngine(File("../../data/tests/models/nlu_engine")).use {
+            it.getIntents("make me two cups of hot tea").apply {
+                assertThat(this).hasSize(3)
+                assertThat(this.map { it.intentName })
+                        .isEqualTo(listOf("MakeTea", "MakeCoffee", null))
+            }
+        }
+    }
+
+    @Test
+    fun getIntentsIntoJsonWorks() {
+        NluEngine(File("../../data/tests/models/nlu_engine")).use {
+            it.getIntentsIntoJson("make me two cups of hot tea").apply {
+                assertThat(this).isNotNull()
+                assertThat(this).contains("MakeTea")
+                assertThat(this).contains("MakeCoffee")
+                assertThat(this).contains("null")
+            }
+        }
+    }
+
+    @Test
     fun funkyCharsArePreserved() {
         NluEngine(File("../../data/tests/models/nlu_engine")).use {
             it.parse("&€£ôœþかたな刀☺ ̿ ̿ ̿'̿'\\̵͇̿̿\\з=(•_•)=ε/̵͇̿̿/'̿'̿ ̿").apply {

--- a/platforms/python/ffi/src/lib.rs
+++ b/platforms/python/ffi/src/lib.rs
@@ -2,7 +2,7 @@ extern crate ffi_utils;
 extern crate libc;
 extern crate snips_nlu_ffi;
 
-use ffi_utils::SNIPS_RESULT;
+use ffi_utils::{CStringArray, SNIPS_RESULT};
 use snips_nlu_ffi::CSnipsNluEngine;
 
 #[doc(hidden)]
@@ -21,7 +21,7 @@ macro_rules! export_c_symbol {
 
 export_c_symbol!(ffi_snips_nlu_engine_create_from_dir, fn snips_nlu_engine_create_from_dir(root_dir: *const libc::c_char, client: *mut *const CSnipsNluEngine) -> SNIPS_RESULT);
 export_c_symbol!(ffi_snips_nlu_engine_create_from_zip, fn snips_nlu_engine_create_from_zip(zip: *const libc::c_uchar, zip_size: libc::c_uint, client: *mut *const CSnipsNluEngine) -> SNIPS_RESULT);
-export_c_symbol!(ffi_snips_nlu_engine_run_parse_into_json, fn snips_nlu_engine_run_parse_into_json(client: *const CSnipsNluEngine, input: *const libc::c_char, result_json: *mut *const libc::c_char) -> SNIPS_RESULT);
+export_c_symbol!(ffi_snips_nlu_engine_run_parse_into_json, fn snips_nlu_engine_run_parse_into_json(client: *const CSnipsNluEngine, input: *const libc::c_char, intents_whitelist: *const CStringArray, intents_blacklist: *const CStringArray, result_json: *mut *const libc::c_char) -> SNIPS_RESULT);
 export_c_symbol!(ffi_snips_nlu_engine_get_last_error, fn snips_nlu_engine_get_last_error(error: *mut *const libc::c_char) -> SNIPS_RESULT);
 export_c_symbol!(ffi_snips_nlu_engine_destroy_string, fn snips_nlu_engine_destroy_string(string: *mut libc::c_char) -> SNIPS_RESULT);
 export_c_symbol!(ffi_snips_nlu_engine_destroy_client, fn snips_nlu_engine_destroy_client(client: *mut CSnipsNluEngine) -> SNIPS_RESULT);

--- a/platforms/python/ffi/src/lib.rs
+++ b/platforms/python/ffi/src/lib.rs
@@ -22,6 +22,8 @@ macro_rules! export_c_symbol {
 export_c_symbol!(ffi_snips_nlu_engine_create_from_dir, fn snips_nlu_engine_create_from_dir(root_dir: *const libc::c_char, client: *mut *const CSnipsNluEngine) -> SNIPS_RESULT);
 export_c_symbol!(ffi_snips_nlu_engine_create_from_zip, fn snips_nlu_engine_create_from_zip(zip: *const libc::c_uchar, zip_size: libc::c_uint, client: *mut *const CSnipsNluEngine) -> SNIPS_RESULT);
 export_c_symbol!(ffi_snips_nlu_engine_run_parse_into_json, fn snips_nlu_engine_run_parse_into_json(client: *const CSnipsNluEngine, input: *const libc::c_char, intents_whitelist: *const CStringArray, intents_blacklist: *const CStringArray, result_json: *mut *const libc::c_char) -> SNIPS_RESULT);
+export_c_symbol!(ffi_snips_nlu_engine_run_get_slots_into_json, fn snips_nlu_engine_run_get_slots_into_json(client: *const CSnipsNluEngine, input: *const libc::c_char, intent: *const libc::c_char, result_json: *mut *const libc::c_char) -> SNIPS_RESULT);
+export_c_symbol!(ffi_snips_nlu_engine_run_get_intents_into_json, fn snips_nlu_engine_run_get_intents_into_json(client: *const CSnipsNluEngine, input: *const libc::c_char, result_json: *mut *const libc::c_char) -> SNIPS_RESULT);
 export_c_symbol!(ffi_snips_nlu_engine_get_last_error, fn snips_nlu_engine_get_last_error(error: *mut *const libc::c_char) -> SNIPS_RESULT);
 export_c_symbol!(ffi_snips_nlu_engine_destroy_string, fn snips_nlu_engine_destroy_string(string: *mut libc::c_char) -> SNIPS_RESULT);
 export_c_symbol!(ffi_snips_nlu_engine_destroy_client, fn snips_nlu_engine_destroy_client(client: *mut CSnipsNluEngine) -> SNIPS_RESULT);

--- a/platforms/python/snips_nlu_rust/nlu_engine.py
+++ b/platforms/python/snips_nlu_rust/nlu_engine.py
@@ -25,7 +25,7 @@ class NLUEngine(object):
                               % str(engine_dir))
             self._engine = pointer(c_void_p())
             exit_code = lib.ffi_snips_nlu_engine_create_from_dir(
-                str(engine_dir).encode("utf-8"), byref(self._engine))
+                str(engine_dir).encode("utf8"), byref(self._engine))
         elif engine_bytes is not None:
             self._engine = pointer(c_void_p())
             bytearray_type = c_char * len(engine_bytes)
@@ -58,11 +58,25 @@ class NLUEngine(object):
             intents_blacklist = byref(arr)
         with string_pointer(c_char_p()) as ptr:
             lib.ffi_snips_nlu_engine_run_parse_into_json(
-                self._engine, query.encode("utf-8"), intents_whitelist, intents_blacklist,
+                self._engine, query.encode("utf8"), intents_whitelist, intents_blacklist,
                 byref(ptr))
             result = string_at(ptr)
 
-        return json.loads(result.decode("utf-8"))
+        return json.loads(result.decode("utf8"))
+
+    def get_slots(self, query, intent):
+        with string_pointer(c_char_p()) as ptr:
+            lib.ffi_snips_nlu_engine_run_get_slots_into_json(
+                self._engine, query.encode("utf8"), intent.encode("utf8"), byref(ptr))
+            result = string_at(ptr)
+        return json.loads(result.decode("utf8"))
+
+    def get_intents(self, query):
+        with string_pointer(c_char_p()) as ptr:
+            lib.ffi_snips_nlu_engine_run_get_intents_into_json(
+                self._engine, query.encode("utf8"), byref(ptr))
+            result = string_at(ptr)
+        return json.loads(result.decode("utf8"))
 
     def __del__(self):
         if self._engine is not None and lib is not None:

--- a/platforms/python/snips_nlu_rust/tests/test_nlu_engine_wrapper.py
+++ b/platforms/python/snips_nlu_rust/tests/test_nlu_engine_wrapper.py
@@ -48,3 +48,34 @@ class TestNLUEngineWrapper(unittest.TestCase):
 
         # Then
         self.assertEqual("MakeTea", res["intent"]["intentName"])
+
+    def test_should_get_slots(self):
+        # Given
+        engine = NLUEngine(engine_bytes=SAMPLE_ENGINE_ZIP_BYTES)
+
+        # Then
+        slots = engine.get_slots("Make me two cups of coffee please", intent="MakeCoffee")
+
+        # Then
+        expected_slots = [
+            {
+                "entity": "snips/number",
+                "range": {"end": 11, "start": 8},
+                "rawValue": "two",
+                "slotName": "number_of_cups",
+                "value": {"kind": "Number", "value": 2.0}
+            }
+        ]
+        self.assertEqual(expected_slots, slots)
+
+    def test_should_get_intents(self):
+        # Given
+        engine = NLUEngine(engine_bytes=SAMPLE_ENGINE_ZIP_BYTES)
+
+        # Then
+        intents_results = engine.get_intents("Make me two cups of coffee please")
+        intents = [res["intentName"] for res in intents_results]
+
+        # Then
+        expected_intents = ["MakeCoffee", "MakeTea", None]
+        self.assertEqual(expected_intents, intents)

--- a/platforms/python/snips_nlu_rust/tests/test_nlu_engine_wrapper.py
+++ b/platforms/python/snips_nlu_rust/tests/test_nlu_engine_wrapper.py
@@ -28,3 +28,23 @@ class TestNLUEngineWrapper(unittest.TestCase):
 
         # Then
         self.assertEqual("MakeCoffee", res["intent"]["intentName"])
+
+    def test_should_parse_with_whitelist(self):
+        # Given
+        engine = NLUEngine(engine_bytes=SAMPLE_ENGINE_ZIP_BYTES)
+
+        # Then
+        res = engine.parse("Make me two cups of coffee please", intents_whitelist=["MakeTea"])
+
+        # Then
+        self.assertEqual("MakeTea", res["intent"]["intentName"])
+
+    def test_should_parse_with_blacklist(self):
+        # Given
+        engine = NLUEngine(engine_bytes=SAMPLE_ENGINE_ZIP_BYTES)
+
+        # Then
+        res = engine.parse("Make me two cups of coffee please", intents_blacklist=["MakeCoffee"])
+
+        # Then
+        self.assertEqual("MakeTea", res["intent"]["intentName"])

--- a/platforms/python/snips_nlu_rust/utils.py
+++ b/platforms/python/snips_nlu_rust/utils.py
@@ -1,5 +1,6 @@
+from _ctypes import Structure, POINTER
 from contextlib import contextmanager
-from ctypes import cdll
+from ctypes import cdll, c_char_p, c_int32
 from pathlib import Path
 
 dylib_dir = Path(__file__).parent / "dylib"
@@ -13,3 +14,10 @@ def string_pointer(ptr):
         yield ptr
     finally:
         lib.ffi_snips_nlu_engine_destroy_string(ptr)
+
+
+class CStringArray(Structure):
+    _fields_ = [
+        ("data", POINTER(c_char_p)),
+        ("size", c_int32)
+    ]

--- a/platforms/swift/SnipsNlu/SnipsNlu.xcodeproj/project.pbxproj
+++ b/platforms/swift/SnipsNlu/SnipsNlu.xcodeproj/project.pbxproj
@@ -258,7 +258,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0830;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = Snips;
 				TargetAttributes = {
 					F76504BD1EFD086C007FF022 = {
@@ -273,22 +273,23 @@
 					};
 					F76504DE1EFD08A8007FF022 = {
 						CreatedOnToolsVersion = 8.3.3;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 					F76504E61EFD08A8007FF022 = {
 						CreatedOnToolsVersion = 8.3.3;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 				};
 			};
 			buildConfigurationList = F76504B81EFD086C007FF022 /* Build configuration list for PBXProject "SnipsNlu" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = F76504B41EFD086C007FF022;
 			productRefGroup = F76504BF1EFD086C007FF022 /* Products */;
@@ -422,6 +423,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -469,7 +471,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
@@ -484,6 +486,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -525,7 +528,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -631,7 +634,7 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_INCLUDE_PATHS = "${PROJECT_DIR}/Dependencies/macos";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -655,7 +658,7 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_INCLUDE_PATHS = "${PROJECT_DIR}/Dependencies/macos";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -672,7 +675,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -688,7 +691,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = ai.snips.SnipsNluTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/platforms/swift/SnipsNlu/SnipsNlu.xcodeproj/xcshareddata/xcschemes/SnipsNlu-iOS.xcscheme
+++ b/platforms/swift/SnipsNlu/SnipsNlu.xcodeproj/xcshareddata/xcschemes/SnipsNlu-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/platforms/swift/SnipsNlu/SnipsNlu.xcodeproj/xcshareddata/xcschemes/SnipsNlu-macOS.xcscheme
+++ b/platforms/swift/SnipsNlu/SnipsNlu.xcodeproj/xcshareddata/xcschemes/SnipsNlu-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/platforms/swift/SnipsNlu/SnipsNlu/NluEngine.swift
+++ b/platforms/swift/SnipsNlu/SnipsNlu/NluEngine.swift
@@ -126,7 +126,7 @@ public enum SlotValue {
             let x = cSlotValue.value.assumingMemoryBound(to: CChar.self)
             self = .musicTrack(String(cString: x))
 
-        default: throw NluEngineError(message: "Internal error: Bad type conversion")
+        default: throw NluEngineError(message: "Internal error: \(cSlotValue.value_type) is not a valid slot value type")
         }
     }
 }
@@ -287,7 +287,7 @@ public enum Grain {
         case SNIPS_GRAIN_HOUR: self = .hour
         case SNIPS_GRAIN_MINUTE: self = .minute
         case SNIPS_GRAIN_SECOND: self = .second
-        default: throw NluEngineError(message: "Internal error: Bad type conversion")
+        default: throw NluEngineError(message: "Internal error: \(cValue) is not a valid datetime grain value")
         }
     }
 }
@@ -300,7 +300,7 @@ public enum Precision {
         switch cValue {
         case SNIPS_PRECISION_APPROXIMATE: self = .approximate
         case SNIPS_PRECISION_EXACT: self = .exact
-        default: throw NluEngineError(message: "Internal error: Bad type conversion")
+        default: throw NluEngineError(message: "Internal error: \(cValue) is not a valid datetime precision value")
         }
     }
 }
@@ -418,12 +418,11 @@ public class NluEngine {
             throw NluEngineError.getLast
         }
 
-        guard let result = cResult?.pointee else { throw NluEngineError(message: "Can't retrieve result")}
+        guard let result = cResult?.pointee else { throw NluEngineError(message: "Can't retrieve parsing result")}
         return try IntentParserResult(cResult: result)
     }
     
     /**
-     
      Extracts slots from the input when the intent is known
      
      - Parameter string: input to process
@@ -439,12 +438,12 @@ public class NluEngine {
             throw NluEngineError.getLast
         }
         
-        guard let cSlotList = cSlots?.pointee else { throw NluEngineError(message: "Can't retrieve result")}
+        guard let cSlotList = cSlots?.pointee else { throw NluEngineError(message: "Can't retrieve slots result")}
         return try UnsafeBufferPointer(start: cSlotList.slots, count: Int(cSlotList.size)).map(Slot.init)
     }
     
     /**
-     Extract the list of intents ranked by their confidence score
+     Extracts the list of intents ranked by their confidence score
      */
     public func getIntents(string: String) throws -> [IntentClassifierResult] {
         var cResults: UnsafePointer<CIntentClassifierResultList>? = nil;
@@ -456,7 +455,7 @@ public class NluEngine {
             throw NluEngineError.getLast
         }
         
-        guard let cResultList = cResults?.pointee else { throw NluEngineError(message: "Can't retrieve result")}
+        guard let cResultList = cResults?.pointee else { throw NluEngineError(message: "Can't retrieve intents result")}
         return UnsafeBufferPointer(start: cResultList.intent_classifier_results, count: Int(cResultList.size)).map(IntentClassifierResult.init)
     }
 }

--- a/platforms/swift/SnipsNlu/SnipsNlu/NluEngine.swift
+++ b/platforms/swift/SnipsNlu/SnipsNlu/NluEngine.swift
@@ -31,11 +31,19 @@ public struct IntentParserResult {
         let cSlotList = cResult.slots.pointee
         self.slots = try UnsafeBufferPointer(start: cSlotList.slots, count: Int(cSlotList.size)).map(Slot.init)
     }
+    
+    init(input: String, intent: IntentClassifierResult, slots: [Slot]) {
+        self.input = input
+        self.intent = intent
+        self.slots = slots
+    }
 }
+
+extension IntentParserResult: Equatable {}
 
 public struct IntentClassifierResult {
     public let intentName: String?
-    public let probability: Float
+    public let confidenceScore: Float
 
     init(cResult: CIntentClassifierResult) {
         if let cIntentName = cResult.intent_name {
@@ -43,9 +51,16 @@ public struct IntentClassifierResult {
         } else {
             self.intentName = nil
         }
-        self.probability = cResult.probability
+        self.confidenceScore = cResult.confidence_score
+    }
+    
+    init(intentName: String?, confidenceScore: Float) {
+        self.intentName = intentName
+        self.confidenceScore = confidenceScore
     }
 }
+
+extension IntentClassifierResult: Equatable {}
 
 public enum SlotValue {
     case custom(String)
@@ -116,6 +131,8 @@ public enum SlotValue {
     }
 }
 
+extension SlotValue: Equatable {}
+
 public typealias NumberValue = Double
 
 public typealias PercentageValue = Double
@@ -132,7 +149,15 @@ public struct InstantTimeValue {
         self.grain = try Grain(cValue: cValue.grain)
         self.precision = try Precision(cValue: cValue.precision)
     }
+    
+    init(value: String, grain: Grain, precision: Precision) {
+        self.value = value
+        self.grain = grain
+        self.precision = precision
+    }
 }
+
+extension InstantTimeValue: Equatable {}
 
 public struct TimeIntervalValue {
     public let from: String?
@@ -150,7 +175,14 @@ public struct TimeIntervalValue {
             self.to = nil
         }
     }
+    
+    init(from: String?, to: String?) {
+        self.from = from
+        self.to = to
+    }
 }
+
+extension TimeIntervalValue: Equatable {}
 
 public struct AmountOfMoneyValue {
      public let value: Float
@@ -166,7 +198,15 @@ public struct AmountOfMoneyValue {
             self.unit = nil
         }
     }
+    
+    init(value: Float, precision: Precision, unit: String?) {
+        self.value = value
+        self.precision = precision
+        self.unit = unit
+    }
 }
+
+extension AmountOfMoneyValue: Equatable {}
 
 public struct TemperatureValue {
      public let value: Float
@@ -180,7 +220,14 @@ public struct TemperatureValue {
             self.unit = nil
         }
     }
+    
+    init(value: Float, unit: String?) {
+        self.value = value
+        self.unit = unit
+    }
 }
+
+extension TemperatureValue: Equatable {}
 
 public struct DurationValue {
      public let years: Int
@@ -204,7 +251,21 @@ public struct DurationValue {
         self.seconds = Int(truncatingIfNeeded: cValue.seconds)
         self.precision = try Precision(cValue: cValue.precision)
     }
+    
+    init(years: Int, quarters: Int, months: Int, weeks: Int, days: Int, hours: Int, minutes: Int, seconds: Int, precision: Precision) {
+        self.years = years
+        self.quarters = quarters
+        self.months = months
+        self.weeks = weeks
+        self.days = days
+        self.hours = hours
+        self.minutes = minutes
+        self.seconds = seconds
+        self.precision = precision
+    }
 }
+
+extension DurationValue: Equatable {}
 
 public enum Grain {
     case year
@@ -244,7 +305,7 @@ public enum Precision {
     }
 }
 
-public struct Slot {
+public struct Slot: Equatable {
     public let rawValue: String
     public let value: SlotValue
     public let range: Range<Int>
@@ -260,18 +321,60 @@ public struct Slot {
         self.slotName = String(cString: cSlot.slot_name)
         self.confidenceScore = cSlot.confidence_score >= 0 ? cSlot.confidence_score : nil
     }
+    
+    init(rawValue: String, value: SlotValue, range: Range<Int>, entity: String, slotName: String, confidenceScore: Float? = nil) {
+        self.rawValue = rawValue
+        self.value = value
+        self.range = range
+        self.entity = entity
+        self.slotName = slotName
+        self.confidenceScore = confidenceScore
+    }
+}
+
+extension CStringArray {
+    init(array: [String]) {
+        let data = UnsafeMutablePointer<UnsafePointer<Int8>?>.allocate(capacity: array.count)
+        array.enumerated().forEach {
+            data.advanced(by: $0).pointee = UnsafePointer(strdup($1))
+        }
+        
+        self.init()
+        self.data = UnsafePointer(data)
+        self.size = Int32(array.count)
+    }
+    
+    func destroy() {
+        let mutating = UnsafeMutablePointer(mutating: data)
+        for idx in 0..<size {
+            free(UnsafeMutableRawPointer(mutating: data.advanced(by: Int(idx)).pointee))
+        }
+        mutating?.deallocate()
+    }
 }
 
 public class NluEngine {
     private var client: OpaquePointer? = nil
 
+    /**
+     Loads an NluEngine from a directory
+     */
     public init(nluEngineDirectoryURL: URL) throws {
-        guard snips_nlu_engine_create_from_dir(nluEngineDirectoryURL.path, &client) == SNIPS_RESULT_OK else { throw NluEngineError.getLast }
+        guard snips_nlu_engine_create_from_dir(nluEngineDirectoryURL.path, &client) == SNIPS_RESULT_OK else {
+            throw NluEngineError.getLast
+        }
     }
 
+    /**
+     Loads an NluEngine from zipped data
+     
+     - Parameter nluEngineZipData: Binary data corresponding to a zipped NluEngine instance
+     */
     public init(nluEngineZipData: Data) throws {
-        try nluEngineZipData.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) in
-            guard snips_nlu_engine_create_from_zip(bytes, UInt32(nluEngineZipData.count), &client) == SNIPS_RESULT_OK else { throw NluEngineError.getLast }
+        try nluEngineZipData.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) in
+            guard snips_nlu_engine_create_from_zip(bytes.baseAddress?.assumingMemoryBound(to: UInt8.self), UInt32(nluEngineZipData.count), &client) == SNIPS_RESULT_OK else {
+                throw NluEngineError.getLast
+            }
         }
     }
 
@@ -282,12 +385,39 @@ public class NluEngine {
         }
     }
 
-    public func parse(string: String) throws -> IntentParserResult {
+    /**
+     Extracts intent and slots from the input
+     
+     - Parameter string: input to process
+     - Parameter intentsWhitelist: optional list of intents used to restrict the parsing scope
+     - Parameter intentsBlacklist: optional list of intents to exclude during parsing
+     */
+    public func parse(string: String, intentsWhitelist: [String]? = nil, intentsBlacklist: [String]? = nil) throws -> IntentParserResult {
         var cResult: UnsafePointer<CIntentParserResult>? = nil;
-        guard snips_nlu_engine_run_parse(self.client, string, &cResult) == SNIPS_RESULT_OK else { throw NluEngineError.getLast }
+        var whiteListArray: CStringArray?
+        var blackListArray: CStringArray?
         defer {
             snips_nlu_engine_destroy_result(UnsafeMutablePointer(mutating: cResult))
+            whiteListArray?.destroy()
+            blackListArray?.destroy()
         }
+        var whitelist: UnsafePointer<CStringArray>?
+        var blacklist: UnsafePointer<CStringArray>?
+        
+        if let unwrappedIntentsWhitelist = intentsWhitelist {
+            whiteListArray = CStringArray(array: unwrappedIntentsWhitelist)
+            whitelist = withUnsafePointer(to: &whiteListArray!) { $0 }
+        }
+        
+        if let unwrappedIntentsBlacklist = intentsBlacklist {
+            blackListArray = CStringArray(array: unwrappedIntentsBlacklist)
+            blacklist = withUnsafePointer(to: &blackListArray!) { $0 }
+        }
+        
+        guard snips_nlu_engine_run_parse(self.client, string, whitelist, blacklist, &cResult) == SNIPS_RESULT_OK else {
+            throw NluEngineError.getLast
+        }
+
         guard let result = cResult?.pointee else { throw NluEngineError(message: "Can't retrieve result")}
         return try IntentParserResult(cResult: result)
     }

--- a/platforms/swift/SnipsNlu/SnipsNluTests/NluEngineTests.swift
+++ b/platforms/swift/SnipsNlu/SnipsNluTests/NluEngineTests.swift
@@ -26,4 +26,37 @@ class NluEngineTests: XCTestCase {
 
         XCTAssertNotNil(nluEngine)
     }
+
+    func testParse() {
+        let directoryURL = Bundle(for: type(of: self)).url(forResource: "nlu_engine", withExtension: nil)!
+
+        let nluEngine = try! NluEngine(nluEngineDirectoryURL: directoryURL)
+
+        let result = try! nluEngine.parse(string: "Make me two coffees please")
+        let expectedSlot = Slot(rawValue: "two", value: SlotValue.number(2.0), range: 8..<11, entity: "snips/number", slotName: "number_of_cups")
+        XCTAssertEqual("MakeCoffee", result.intent.intentName)
+        XCTAssertEqual([expectedSlot], result.slots)
+    }
+    
+    func testParseWithWhitelist() {
+        let directoryURL = Bundle(for: type(of: self)).url(forResource: "nlu_engine", withExtension: nil)!
+
+        let nluEngine = try! NluEngine(nluEngineDirectoryURL: directoryURL)
+
+        let result = try! nluEngine.parse(string: "Make me two cups of coffee please", intentsWhitelist: ["MakeTea"])
+        let expectedSlot = Slot(rawValue: "two", value: SlotValue.number(2.0), range: 8..<11, entity: "snips/number", slotName: "number_of_cups")
+        XCTAssertEqual("MakeTea", result.intent.intentName)
+        XCTAssertEqual([expectedSlot], result.slots)
+    }
+    
+    func testParseWithBlacklist() {
+        let directoryURL = Bundle(for: type(of: self)).url(forResource: "nlu_engine", withExtension: nil)!
+        
+        let nluEngine = try! NluEngine(nluEngineDirectoryURL: directoryURL)
+        
+        let result = try! nluEngine.parse(string: "Make me two cups of coffee please", intentsBlacklist: ["MakeCoffee"])
+        let expectedSlot = Slot(rawValue: "two", value: SlotValue.number(2.0), range: 8..<11, entity: "snips/number", slotName: "number_of_cups")
+        XCTAssertEqual("MakeTea", result.intent.intentName)
+        XCTAssertEqual([expectedSlot], result.slots)
+    }
 }

--- a/platforms/swift/SnipsNlu/SnipsNluTests/NluEngineTests.swift
+++ b/platforms/swift/SnipsNlu/SnipsNluTests/NluEngineTests.swift
@@ -59,4 +59,25 @@ class NluEngineTests: XCTestCase {
         XCTAssertEqual("MakeTea", result.intent.intentName)
         XCTAssertEqual([expectedSlot], result.slots)
     }
+    
+    func testGetSlots() {
+        let directoryURL = Bundle(for: type(of: self)).url(forResource: "nlu_engine", withExtension: nil)!
+        
+        let nluEngine = try! NluEngine(nluEngineDirectoryURL: directoryURL)
+        
+        let slots = try! nluEngine.getSlots(string: "Make me two cups of coffee please", intent: "MakeCoffee")
+        let expectedSlot = Slot(rawValue: "two", value: SlotValue.number(2.0), range: 8..<11, entity: "snips/number", slotName: "number_of_cups")
+        XCTAssertEqual([expectedSlot], slots)
+    }
+    
+    func testGetIntents() {
+        let directoryURL = Bundle(for: type(of: self)).url(forResource: "nlu_engine", withExtension: nil)!
+        
+        let nluEngine = try! NluEngine(nluEngineDirectoryURL: directoryURL)
+        
+        let intentsResults = try! nluEngine.getIntents(string: "Make me two cups of coffee please")
+        let intents = intentsResults.map { $0.intentName }
+        let expectedIntents = ["MakeCoffee", "MakeTea", nil]
+        XCTAssertEqual(expectedIntents, intents)
+    }
 }

--- a/update_version.sh
+++ b/update_version.sh
@@ -4,6 +4,7 @@ NEW_VERSION=${1?"usage $0 <new version>"}
 
 echo "Updating versions to version ${NEW_VERSION}"
 find . -name "Cargo.toml" -exec perl -p -i -e "s/^version = \".*\"$/version = \"$NEW_VERSION\"/g" {} \;
+find . -name "cbindgen.toml" -exec perl -p -i -e "s/^header = \"#define SNIPS_NLU_VERSION.*\"$/header = \"#define SNIPS_NLU_VERSION \\\\\"${NEW_VERSION}\\\\\"\"/g" {} \;
 perl -p -i -e "s/^version = \".*\"\$/version = \"$NEW_VERSION\"/g" */**/build.gradle
 perl -p -i -e "s/^VERSION=\".*\"\$/VERSION=\"$NEW_VERSION\"/g" */**/**/**/build.sh
 perl -p -i -e "s/SNIPS_NLU_VERSION \".*\"/SNIPS_NLU_VERSION \"$NEW_VERSION\"/g" platforms/c/libsnips_nlu.h


### PR DESCRIPTION
**Description**
This PR completes the existing ffi with the following missing APIs:
- additional `intents_whitelist` and `intents_blacklist` parameters in the `parse` API
- `get_slots`
- `get_intents`

Additionally, the wrappers built on top of this FFI (python, kotlin, swift) are updated to integrate these changes.