### PR TITLE
Fix error handling in Python wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Fixed
+- Make the `WrongModelVersion` error message intelligible [#133](https://github.com/snipsco/snips-nlu-rs/pull/133)
+- Fix error handling in Python wrapper [#134](https://github.com/snipsco/snips-nlu-rs/pull/134)
+
 ## [0.64.2] - 2019-04-09
 ### Fixed
 - Fix handling of ambiguous utterances in `DeterministicIntentParser` [#129](https://github.com/snipsco/snips-nlu-rs/pull/129)
@@ -189,6 +194,7 @@ being statically hardcoded, reducing the binary size by 31Mb.
 - Improve support for japanese
 - Rename python package to `snips_nlu_rust`
 
+[Unreleased]: https://github.com/snipsco/snips-nlu-rs/compare/0.64.2...HEAD
 [0.64.2]: https://github.com/snipsco/snips-nlu-rs/compare/0.64.1...0.64.2
 [0.64.1]: https://github.com/snipsco/snips-nlu-rs/compare/0.64.0...0.64.1
 [0.64.0]: https://github.com/snipsco/snips-nlu-rs/compare/0.63.1...0.64.0

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -3,7 +3,7 @@
 extern crate ffi_utils;
 extern crate snips_nlu_ontology_ffi_macros;
 
-use std::ffi::{CStr, CString};
+use std::ffi::CStr;
 use std::io::Cursor;
 use std::slice;
 use std::sync::Mutex;
@@ -119,11 +119,15 @@ pub extern "C" fn snips_nlu_engine_run_get_intents_into_json(
 
 #[no_mangle]
 pub extern "C" fn snips_nlu_engine_destroy_string(string: *mut libc::c_char) -> SNIPS_RESULT {
-    wrap!(unsafe { CString::from_raw_pointer(string) })
+    take_back_nullable_c_string!(string);
+    SNIPS_RESULT::SNIPS_RESULT_OK
 }
 
 #[no_mangle]
 pub extern "C" fn snips_nlu_engine_destroy_client(client: *mut CSnipsNluEngine) -> SNIPS_RESULT {
+    if client.is_null() {
+        return SNIPS_RESULT::SNIPS_RESULT_OK
+    }
     wrap!(unsafe { CSnipsNluEngine::from_raw_pointer(client) })
 }
 
@@ -131,11 +135,17 @@ pub extern "C" fn snips_nlu_engine_destroy_client(client: *mut CSnipsNluEngine) 
 pub extern "C" fn snips_nlu_engine_destroy_result(
     result: *mut CIntentParserResult,
 ) -> SNIPS_RESULT {
+    if result.is_null() {
+        return SNIPS_RESULT::SNIPS_RESULT_OK
+    }
     wrap!(unsafe { CIntentParserResult::from_raw_pointer(result) })
 }
 
 #[no_mangle]
 pub extern "C" fn snips_nlu_engine_destroy_slots(result: *mut CSlotList) -> SNIPS_RESULT {
+    if result.is_null() {
+        return SNIPS_RESULT::SNIPS_RESULT_OK
+    }
     wrap!(unsafe { CSlotList::from_raw_pointer(result) })
 }
 
@@ -143,6 +153,9 @@ pub extern "C" fn snips_nlu_engine_destroy_slots(result: *mut CSlotList) -> SNIP
 pub extern "C" fn snips_nlu_engine_destroy_intent_classifier_results(
     result: *mut CIntentClassifierResultArray,
 ) -> SNIPS_RESULT {
+    if result.is_null() {
+        return SNIPS_RESULT::SNIPS_RESULT_OK
+    }
     wrap!(unsafe { CIntentClassifierResultArray::from_raw_pointer(result) })
 }
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -3,7 +3,7 @@
 extern crate ffi_utils;
 extern crate snips_nlu_ontology_ffi_macros;
 
-use std::ffi::CStr;
+use std::ffi::{CStr, CString};
 use std::io::Cursor;
 use std::slice;
 use std::sync::Mutex;
@@ -119,15 +119,11 @@ pub extern "C" fn snips_nlu_engine_run_get_intents_into_json(
 
 #[no_mangle]
 pub extern "C" fn snips_nlu_engine_destroy_string(string: *mut libc::c_char) -> SNIPS_RESULT {
-    take_back_nullable_c_string!(string);
-    SNIPS_RESULT::SNIPS_RESULT_OK
+    wrap!(unsafe { CString::from_raw_pointer(string) })
 }
 
 #[no_mangle]
 pub extern "C" fn snips_nlu_engine_destroy_client(client: *mut CSnipsNluEngine) -> SNIPS_RESULT {
-    if client.is_null() {
-        return SNIPS_RESULT::SNIPS_RESULT_OK
-    }
     wrap!(unsafe { CSnipsNluEngine::from_raw_pointer(client) })
 }
 
@@ -135,17 +131,11 @@ pub extern "C" fn snips_nlu_engine_destroy_client(client: *mut CSnipsNluEngine) 
 pub extern "C" fn snips_nlu_engine_destroy_result(
     result: *mut CIntentParserResult,
 ) -> SNIPS_RESULT {
-    if result.is_null() {
-        return SNIPS_RESULT::SNIPS_RESULT_OK
-    }
     wrap!(unsafe { CIntentParserResult::from_raw_pointer(result) })
 }
 
 #[no_mangle]
 pub extern "C" fn snips_nlu_engine_destroy_slots(result: *mut CSlotList) -> SNIPS_RESULT {
-    if result.is_null() {
-        return SNIPS_RESULT::SNIPS_RESULT_OK
-    }
     wrap!(unsafe { CSlotList::from_raw_pointer(result) })
 }
 
@@ -153,9 +143,6 @@ pub extern "C" fn snips_nlu_engine_destroy_slots(result: *mut CSlotList) -> SNIP
 pub extern "C" fn snips_nlu_engine_destroy_intent_classifier_results(
     result: *mut CIntentClassifierResultArray,
 ) -> SNIPS_RESULT {
-    if result.is_null() {
-        return SNIPS_RESULT::SNIPS_RESULT_OK
-    }
     wrap!(unsafe { CIntentClassifierResultArray::from_raw_pointer(result) })
 }
 

--- a/platforms/python/snips_nlu_rust/nlu_engine.py
+++ b/platforms/python/snips_nlu_rust/nlu_engine.py
@@ -4,10 +4,11 @@ from __future__ import (absolute_import, division, print_function,
 
 import json
 from builtins import object, str
-from ctypes import byref, c_char_p, c_void_p, pointer, string_at, c_char, c_int
+from ctypes import byref, c_char_p, c_void_p, string_at, c_char, c_int
 from pathlib import Path
 
-from snips_nlu_rust.utils import lib, string_pointer, CStringArray
+from snips_nlu_rust.utils import (
+    lib, string_pointer, CStringArray, check_ffi_error)
 
 
 class NLUEngine(object):
@@ -32,8 +33,8 @@ class NLUEngine(object):
         ...     engine_dir="/path/to/nlu_engine")
         >>> inference_engine.parse("Turn on the lights in the kitchen")
     """
+
     def __init__(self, engine_dir=None, engine_bytes=None):
-        exit_code = 1
         self._engine = None
 
         if engine_dir is None and engine_bytes is None:
@@ -41,61 +42,65 @@ class NLUEngine(object):
 
         if engine_dir is not None:
             engine_dir = Path(engine_dir)
-            if not engine_dir.is_dir():
-                raise OSError("NLU engine directory not found: %s"
-                              % str(engine_dir))
-            self._engine = pointer(c_void_p())
+            self._engine = c_void_p()
             exit_code = lib.ffi_snips_nlu_engine_create_from_dir(
                 str(engine_dir).encode("utf8"), byref(self._engine))
-        elif engine_bytes is not None:
-            self._engine = pointer(c_void_p())
+            err_msg = "Something went wrong when creating the engine from " \
+                      "directory"
+
+        else:
+            self._engine = c_void_p()
             bytearray_type = c_char * len(engine_bytes)
             exit_code = lib.ffi_snips_nlu_engine_create_from_zip(
                 bytearray_type.from_buffer(engine_bytes), len(engine_bytes),
                 byref(self._engine))
+            err_msg = "Something went wrong when creating the engine from " \
+                      "bytes"
 
-        if exit_code:
-            raise ImportError('Something wrong happened while creating the '
-                              'intent parser. See stderr.')
+        check_ffi_error(exit_code, err_msg)
 
     def parse(self, query, intents_whitelist=None, intents_blacklist=None):
         """Extracts intent and slots from an input query
 
         Args:
             query (str): input to process
-            intents_whitelist (list of str, optional): if defined, this will restrict the scope of
-                intent parsing to the provided intents
-            intents_blacklist (list of str, optional): if defined, these intents will be excluded
-                from the scope of intent parsing
+            intents_whitelist (list of str, optional): if defined, this will
+                restrict the scope of intent parsing to the provided intents
+            intents_blacklist (list of str, optional): if defined, these
+                intents will be excluded from the scope of intent parsing
 
         Returns:
             A python dict containing data about intent and slots. See
-            https://snips-nlu.readthedocs.io/en/latest/tutorial.html#parsing for details about the
-            format.
+            https://snips-nlu.readthedocs.io/en/latest/tutorial.html#parsing
+            for details about the format.
         """
         if intents_whitelist is not None:
-            if not all(isinstance(intent, str) for intent in intents_whitelist):
-                raise TypeError(
-                    "Expected 'intents_whitelist' to contain objects of type 'str'")
+            if not all(
+                    isinstance(intent, str) for intent in intents_whitelist):
+                raise TypeError("Expected 'intents_whitelist' to contain "
+                                "objects of type 'str'")
             intents = [intent.encode("utf8") for intent in intents_whitelist]
             arr = CStringArray()
             arr.size = c_int(len(intents))
             arr.data = (c_char_p * len(intents))(*intents)
             intents_whitelist = byref(arr)
         if intents_blacklist is not None:
-            if not all(isinstance(intent, str) for intent in intents_blacklist):
-                raise TypeError(
-                    "Expected 'intents_blacklist' to contain objects of type 'str'")
+            if not all(
+                    isinstance(intent, str) for intent in intents_blacklist):
+                raise TypeError("Expected 'intents_blacklist' to contain "
+                                "objects of type 'str'")
             intents = [intent.encode("utf8") for intent in intents_blacklist]
             arr = CStringArray()
             arr.size = c_int(len(intents))
             arr.data = (c_char_p * len(intents))(*intents)
             intents_blacklist = byref(arr)
         with string_pointer(c_char_p()) as ptr:
-            lib.ffi_snips_nlu_engine_run_parse_into_json(
-                self._engine, query.encode("utf8"), intents_whitelist, intents_blacklist,
-                byref(ptr))
+            exit_code = lib.ffi_snips_nlu_engine_run_parse_into_json(
+                self._engine, query.encode("utf8"), intents_whitelist,
+                intents_blacklist, byref(ptr))
             result = string_at(ptr)
+            msg = "Something went wrong when parsing query '%s'" % query
+            check_ffi_error(exit_code, msg)
 
         return json.loads(result.decode("utf8"))
 
@@ -108,13 +113,18 @@ class NLUEngine(object):
 
         Returns:
             A list of slots. See
-            https://snips-nlu.readthedocs.io/en/latest/tutorial.html#parsing for details about the
-            format.
+            https://snips-nlu.readthedocs.io/en/latest/tutorial.html#parsing
+            for details about the format.
         """
         with string_pointer(c_char_p()) as ptr:
-            lib.ffi_snips_nlu_engine_run_get_slots_into_json(
-                self._engine, query.encode("utf8"), intent.encode("utf8"), byref(ptr))
+            exit_code = lib.ffi_snips_nlu_engine_run_get_slots_into_json(
+                self._engine, query.encode("utf8"), intent.encode("utf8"),
+                byref(ptr))
+            msg = "Something went wrong when extracting slots from query " \
+                  "'%s' with intent '%s'" % (query, intent)
+            check_ffi_error(exit_code, msg)
             result = string_at(ptr)
+
         return json.loads(result.decode("utf8"))
 
     def get_intents(self, query):
@@ -125,12 +135,15 @@ class NLUEngine(object):
 
         Returns:
             A list of intents along with their probability. See
-            https://snips-nlu.readthedocs.io/en/latest/tutorial.html#parsing for details about the
-            format.
+            https://snips-nlu.readthedocs.io/en/latest/tutorial.html#parsing
+            for details about the format.
         """
         with string_pointer(c_char_p()) as ptr:
-            lib.ffi_snips_nlu_engine_run_get_intents_into_json(
+            exit_code = lib.ffi_snips_nlu_engine_run_get_intents_into_json(
                 self._engine, query.encode("utf8"), byref(ptr))
+            msg = "Something went wrong when extracting intents from query " \
+                  "'%s'" % query
+            check_ffi_error(exit_code, msg)
             result = string_at(ptr)
         return json.loads(result.decode("utf8"))
 

--- a/platforms/python/snips_nlu_rust/nlu_engine.py
+++ b/platforms/python/snips_nlu_rust/nlu_engine.py
@@ -98,9 +98,9 @@ class NLUEngine(object):
             exit_code = lib.ffi_snips_nlu_engine_run_parse_into_json(
                 self._engine, query.encode("utf8"), intents_whitelist,
                 intents_blacklist, byref(ptr))
-            result = string_at(ptr)
             msg = "Something went wrong when parsing query '%s'" % query
             check_ffi_error(exit_code, msg)
+            result = string_at(ptr)
 
         return json.loads(result.decode("utf8"))
 

--- a/platforms/python/snips_nlu_rust/tests/test_nlu_engine_wrapper.py
+++ b/platforms/python/snips_nlu_rust/tests/test_nlu_engine_wrapper.py
@@ -19,6 +19,12 @@ class TestNLUEngineWrapper(unittest.TestCase):
         # Then
         self.assertEqual("MakeCoffee", res["intent"]["intentName"])
 
+    def test_load_from_dir_should_fail_with_invalid_path(self):
+        with self.assertRaises(ValueError) as cm:
+            NLUEngine(engine_dir="/tmp/invalid/path/to/engine")
+
+        self.assertTrue("No such file or directory" in str(cm.exception))
+
     def test_should_load_from_zip_and_parse(self):
         # Given
         engine = NLUEngine(engine_bytes=SAMPLE_ENGINE_ZIP_BYTES)
@@ -29,12 +35,19 @@ class TestNLUEngineWrapper(unittest.TestCase):
         # Then
         self.assertEqual("MakeCoffee", res["intent"]["intentName"])
 
+    def test_load_from_zip_should_fail_with_invalid_data(self):
+        with self.assertRaises(ValueError) as cm:
+            NLUEngine(engine_bytes=bytearray())
+
+        self.assertTrue("Invalid Zip archive" in str(cm.exception))
+
     def test_should_parse_with_whitelist(self):
         # Given
         engine = NLUEngine(engine_bytes=SAMPLE_ENGINE_ZIP_BYTES)
 
         # Then
-        res = engine.parse("Make me two cups of coffee please", intents_whitelist=["MakeTea"])
+        res = engine.parse("Make me two cups of coffee please",
+                           intents_whitelist=["MakeTea"])
 
         # Then
         self.assertEqual("MakeTea", res["intent"]["intentName"])
@@ -44,7 +57,8 @@ class TestNLUEngineWrapper(unittest.TestCase):
         engine = NLUEngine(engine_bytes=SAMPLE_ENGINE_ZIP_BYTES)
 
         # Then
-        res = engine.parse("Make me two cups of coffee please", intents_blacklist=["MakeCoffee"])
+        res = engine.parse("Make me two cups of coffee please",
+                           intents_blacklist=["MakeCoffee"])
 
         # Then
         self.assertEqual("MakeTea", res["intent"]["intentName"])
@@ -54,7 +68,8 @@ class TestNLUEngineWrapper(unittest.TestCase):
         engine = NLUEngine(engine_bytes=SAMPLE_ENGINE_ZIP_BYTES)
 
         # Then
-        slots = engine.get_slots("Make me two cups of coffee please", intent="MakeCoffee")
+        slots = engine.get_slots("Make me two cups of coffee please",
+                                 intent="MakeCoffee")
 
         # Then
         expected_slots = [
@@ -68,12 +83,23 @@ class TestNLUEngineWrapper(unittest.TestCase):
         ]
         self.assertEqual(expected_slots, slots)
 
+    def test_get_slots_should_fail_with_unknown_intent(self):
+        # Given
+        engine = NLUEngine(engine_bytes=SAMPLE_ENGINE_ZIP_BYTES)
+
+        # Then
+        with self.assertRaises(ValueError) as cm:
+            engine.get_slots(
+                "Make me two cups of coffee please", intent="my_intent")
+        self.assertTrue("Unknown intent" in str(cm.exception))
+
     def test_should_get_intents(self):
         # Given
         engine = NLUEngine(engine_bytes=SAMPLE_ENGINE_ZIP_BYTES)
 
         # Then
-        intents_results = engine.get_intents("Make me two cups of coffee please")
+        intents_results = engine.get_intents(
+            "Make me two cups of coffee please")
         intents = [res["intentName"] for res in intents_results]
 
         # Then

--- a/platforms/python/snips_nlu_rust/tests/test_nlu_engine_wrapper.py
+++ b/platforms/python/snips_nlu_rust/tests/test_nlu_engine_wrapper.py
@@ -105,3 +105,10 @@ class TestNLUEngineWrapper(unittest.TestCase):
         # Then
         expected_intents = ["MakeCoffee", "MakeTea", None]
         self.assertEqual(expected_intents, intents)
+
+    def test_engine_should_destroy_itself(self):
+        # Given
+        engine = NLUEngine(engine_bytes=SAMPLE_ENGINE_ZIP_BYTES)
+
+        # When / Then
+        del engine

--- a/platforms/python/snips_nlu_rust/utils.py
+++ b/platforms/python/snips_nlu_rust/utils.py
@@ -1,6 +1,6 @@
-from _ctypes import Structure, POINTER
+from _ctypes import Structure, POINTER, byref
 from contextlib import contextmanager
-from ctypes import cdll, c_char_p, c_int32
+from ctypes import cdll, c_char_p, c_int32, string_at
 from pathlib import Path
 
 dylib_dir = Path(__file__).parent / "dylib"
@@ -21,3 +21,13 @@ class CStringArray(Structure):
         ("data", POINTER(c_char_p)),
         ("size", c_int32)
     ]
+
+
+def check_ffi_error(exit_code, error_context_msg):
+    if exit_code != 0:
+        with string_pointer(c_char_p()) as ptr:
+            if lib.snips_nlu_engine_get_last_error(byref(ptr)) == 0:
+                ffi_error_message = string_at(ptr).decode("utf8")
+            else:
+                ffi_error_message = "see stderr"
+        raise ValueError("%s: %s" % (error_context_msg, ffi_error_message))

--- a/src/intent_classifier/log_reg_intent_classifier.rs
+++ b/src/intent_classifier/log_reg_intent_classifier.rs
@@ -29,7 +29,10 @@ impl LogRegIntentClassifier {
         path: P,
         shared_resources: Arc<SharedResources>,
     ) -> Result<Self> {
-        info!("Loading log reg intent classifier ({:?}) ...", path.as_ref());
+        info!(
+            "Loading log reg intent classifier ({:?}) ...",
+            path.as_ref()
+        );
         let classifier_model_path = path.as_ref().join("intent_classifier.json");
         let model_file = File::open(&classifier_model_path).with_context(|_| {
             format!(

--- a/src/resources/loading.rs
+++ b/src/resources/loading.rs
@@ -106,7 +106,10 @@ fn load_gazetteers<P: AsRef<Path>>(
             let gazetteer_path = gazetteers_directory
                 .join(gazetteer_name.clone())
                 .with_extension("txt");
-            info!("Loading gazetteer '{}' ({:?}) ...", gazetteer_name, gazetteer_path);
+            info!(
+                "Loading gazetteer '{}' ({:?}) ...",
+                gazetteer_name, gazetteer_path
+            );
             let file = File::open(&gazetteer_path)
                 .with_context(|_| format!("Cannot open gazetteer file {:?}", gazetteer_path))?;
             let gazetteer = HashSetGazetteer::from_reader(file)
@@ -130,7 +133,10 @@ fn load_word_clusterers<P: AsRef<Path>>(
                 .join(clusters_name.clone())
                 .with_extension("txt");
             ;
-            info!("Loading word clusters '{}' ({:?}) ...", clusters_name, clusters_path);
+            info!(
+                "Loading word clusters '{}' ({:?}) ...",
+                clusters_name, clusters_path
+            );
             let word_clusters_reader = File::open(&clusters_path)
                 .with_context(|_| format!("Cannot open word clusters file {:?}", clusters_path))?;
             let word_clusterer = HashMapWordClusterer::from_reader(word_clusters_reader)


### PR DESCRIPTION
**Description**
The Rust <--> Python binding was not handling properly errors happening on the Rust side. More precisely, memory behind pointers was deallocated without checking that it had actually been allocated at some point.
When an error occurs in a rust API call, the memory behind the result pointer is often not allocated as the error happens before the result is created.
As a result, instead of getting a python exception, you receive a segmentation fault.