### PR TITLE
Fix issue with stop words in DeterministicIntentParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 - Make the `WrongModelVersion` error message intelligible [#133](https://github.com/snipsco/snips-nlu-rs/pull/133)
 - Fix error handling in Python wrapper [#134](https://github.com/snipsco/snips-nlu-rs/pull/134)
 - Return an error when using unknown intents in whitelist or blacklist [#136](https://github.com/snipsco/snips-nlu-rs/pull/136)
+- Fix issue with stop words in `DeterministicIntentParser` [#137](https://github.com/snipsco/snips-nlu-rs/pull/137)
 
 ## [0.64.2] - 2019-04-09
 ### Fixed

--- a/src/intent_parser/deterministic_intent_parser.rs
+++ b/src/intent_parser/deterministic_intent_parser.rs
@@ -677,7 +677,7 @@ mod tests {
             .iter()
             .map(|res| res.confidence_score)
             .collect::<Vec<_>>();
-        let expected_scores = vec![0.5, 0.5, 0.0, 0.0, 0.0, 0.0];
+        let expected_scores = vec![0.5, 0.5, 0.0, 0.0, 0.0, 0.0, 0.0];
         let intent_names = intents
             .into_iter()
             .skip(2)
@@ -692,6 +692,7 @@ mod tests {
             "dummy_intent_1".to_string(),
             "dummy_intent_2".to_string(),
             "dummy_intent_4".to_string(),
+            "dummy_intent_6".to_string(),
             "null".to_string(),
         ];
         assert_eq!(expected_scores, scores);

--- a/src/models/intent_parser.rs
+++ b/src/models/intent_parser.rs
@@ -10,6 +10,8 @@ pub struct DeterministicParserModel {
     pub patterns: HashMap<IntentName, Vec<String>>,
     pub group_names_to_slot_names: HashMap<String, SlotName>,
     pub slot_names_to_entities: HashMap<IntentName, HashMap<SlotName, EntityName>>,
+    #[serde(default)]
+    pub stop_words_whitelist: HashMap<IntentName, Vec<String>>,
     pub config: DeterministicParserConfig,
 }
 


### PR DESCRIPTION
**Description**
The deterministic intent parser skips words that are in the stop words list. However, words that are both in the stop words list and in the list of entity values should not be skipped, and this is the goal of this PR.