### PR TITLE
Fix caching issue in CustomEntityParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Fix error handling in Python wrapper [#134](https://github.com/snipsco/snips-nlu-rs/pull/134)
 - Return an error when using unknown intents in whitelist or blacklist [#136](https://github.com/snipsco/snips-nlu-rs/pull/136)
 - Fix issue with stop words in `DeterministicIntentParser` [#137](https://github.com/snipsco/snips-nlu-rs/pull/137)
+- Fix caching issue in `CustomEntityParser` [#138](https://github.com/snipsco/snips-nlu-rs/pull/138)
 
 ## [0.64.2] - 2019-04-09
 ### Fixed


### PR DESCRIPTION
**Description**
The way we compute the caching key when calling the `extract_entities` API of the `CustomEntityParser` object was wrong. Indeed, using a `None` scope was treated equally than using an empty (`vec![]`) scope.